### PR TITLE
[REFACTOR] 쿠키 기반 세션 로그인

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,3 +22,5 @@ sqlalchemy
 # pymysql
 pymysql
 
+# itsdangerous - 쿠키 서명 및 검증
+itsdangerous

--- a/backend/src/api/routers/user.py
+++ b/backend/src/api/routers/user.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 
 from schemas.user import UserCreate, UserRead, UserLogin
@@ -25,8 +25,15 @@ def signup(user_in: UserCreate, db: Session = Depends(get_db)):
 
 
 @router.post("/login", response_model=UserRead)
-def login(creds: UserLogin, db: Session = Depends(get_db)):
+def login(
+    creds: UserLogin,
+    request: Request,
+    db: Session = Depends(get_db)
+):
+    
     user = authenticate_user(db, creds)
     if not user:
         raise HTTPException(status_code=401, detail="이메일 또는 비밀번호가 올바르지 않습니다")
+    
+    request.session["user_id"] = user.id
     return user

--- a/backend/src/backend.py
+++ b/backend/src/backend.py
@@ -1,12 +1,14 @@
-from fastapi import FastAPI, Depends
+from fastapi import FastAPI, Depends, Request
 from config.config import settings
 from sqlalchemy.orm import Session
 from sqlalchemy import text
 from db.session import get_db
 from api.routers import user
+from starlette.middleware.sessions import SessionMiddleware
 
 app = FastAPI(title=settings.APP_NAME, debug=settings.DEBUG)
 app.include_router(user.router, prefix="/users", tags=["users"])
+app.add_middleware(SessionMiddleware, secret_key=settings.SECRET_KEY)
 
 @app.get("/")
 def root():

--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -14,5 +14,7 @@ class Settings:
     DB_USER: str = os.getenv("DB_USER")
     DB_PASS: str = os.getenv("DB_PASS")
     DB_NAME: str = os.getenv("DB_NAME")
+    SECRET_KEY: str = os.getenv("SECRET_KEY", "replace-with-your-secret")
+    
 
 settings = Settings()

--- a/backend/src/util/deps.py
+++ b/backend/src/util/deps.py
@@ -1,0 +1,17 @@
+from fastapi import Request, HTTPException, Depends
+from sqlalchemy.orm import Session
+from db.session import get_db
+from crud.user import get_user_by_id
+
+# 로그인된 사용자 정보를 가져오는 함수입니다.
+def get_current_user(
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    user_id = request.session.get("user_id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="인증이 필요합니다")
+    user = get_user_by_id(db, user_id)
+    if not user:
+        raise HTTPException(status_code=401, detail="유효하지 않은 세션입니다")
+    return user


### PR DESCRIPTION
# What is this PR? 🔍

## ➕ 이슈 링크

- issue : #17 

## ➕ 개요

쿠키 기반 세션 로그인 구현

## ➕ 작업 내용

LLM에 질문을 할 때 사용자의 프로필 정보가 자동으로 담겨서 보내도록 하기 위해서는 요청 시 사용자를 특정할 수 있어야 하는데, 기존 로그인 구현에서는 JWT도 세션도 사용하지 않아 불가능했습니다.
해당 PR에서는 간단하게 쿠키 기반 세션 로그인으로 로그인 코드를 리팩토링 했습니다.


