### PR TITLE
[FEAT] 채팅방 관련 API 작업

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ ingestion/dataset.DS_Store
 
 # 로그 파일
 *.log
+
+# 커서 규칙
+.cursorrules

--- a/backend/src/api/routers/chatroom.py
+++ b/backend/src/api/routers/chatroom.py
@@ -1,0 +1,110 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+
+from schemas.chatroom import (
+    ChatroomCreate,
+    ChatroomRead,
+    ChatroomUpdate
+)
+from crud.chatroom import (
+    create_chatroom,
+    get_chatroom,
+    get_chatrooms_by_member,
+    update_chatroom,
+    delete_chatroom
+)
+from db.session import get_db
+from util.deps import get_current_user
+from util.logging import log_api_call
+
+router = APIRouter(prefix="/chatrooms", tags=["chatrooms"])
+
+
+@router.post("", response_model=ChatroomRead, status_code=201)
+@log_api_call
+def create_new_chatroom(
+    data: ChatroomCreate,
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    새로운 채팅방을 생성합니다.
+    
+    - **title**: 채팅방 제목 (선택적)
+    """
+    return create_chatroom(db, current_user.id, data)
+
+
+@router.get("", response_model=List[ChatroomRead])
+@log_api_call
+def get_my_chatrooms(
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    현재 사용자의 모든 채팅방 목록을 조회합니다.
+    
+    - 최근 업데이트 순으로 정렬됩니다.
+    """
+    return get_chatrooms_by_member(db, current_user.id)
+
+
+@router.get("/{chatroom_id}", response_model=ChatroomRead)
+@log_api_call
+def get_chatroom_detail(
+    chatroom_id: int,
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    특정 채팅방의 정보를 조회합니다.
+    """
+    chatroom = get_chatroom(db, chatroom_id, current_user.id)
+    if not chatroom:
+        raise HTTPException(
+            status_code=404,
+            detail="채팅방을 찾을 수 없습니다."
+        )
+    return chatroom
+
+
+@router.patch("/{chatroom_id}", response_model=ChatroomRead)
+@log_api_call
+def update_chatroom_info(
+    chatroom_id: int,
+    data: ChatroomUpdate,
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    채팅방 정보를 수정합니다.
+    
+    - **title**: 채팅방 제목
+    """
+    chatroom = update_chatroom(db, chatroom_id, current_user.id, data)
+    if not chatroom:
+        raise HTTPException(
+            status_code=404,
+            detail="채팅방을 찾을 수 없습니다."
+        )
+    return chatroom
+
+
+@router.delete("/{chatroom_id}")
+@log_api_call
+def delete_chatroom_by_id(
+    chatroom_id: int,
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    채팅방을 삭제합니다. (논리적 삭제)
+    """
+    success = delete_chatroom(db, chatroom_id, current_user.id)
+    if not success:
+        raise HTTPException(
+            status_code=404,
+            detail="채팅방을 찾을 수 없습니다."
+        )
+    return {"message": "채팅방이 삭제되었습니다."} 

--- a/backend/src/backend.py
+++ b/backend/src/backend.py
@@ -4,7 +4,7 @@ from sqlalchemy import text
 from starlette.middleware.sessions import SessionMiddleware
 
 from config.config import settings
-from api.routers import user, profile, course
+from api.routers import user, profile, course, chatroom
 from db.session import get_db
 from util.logging import setup_logging
 
@@ -16,6 +16,7 @@ app.add_middleware(SessionMiddleware, secret_key=settings.SECRET_KEY)
 app.include_router(user.router)
 app.include_router(profile.router)
 app.include_router(course.router)
+app.include_router(chatroom.router)
 
 @app.get("/")
 def root():

--- a/backend/src/crud/chatroom.py
+++ b/backend/src/crud/chatroom.py
@@ -1,0 +1,77 @@
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from db.models import Chatroom, ChatMessage
+from schemas.chatroom import ChatroomCreate, ChatroomUpdate
+from util.logging import log_db_operation
+
+
+@log_db_operation("SELECT")
+def get_chatroom(db: Session, chatroom_id: int, member_id: str) -> Optional[Chatroom]:
+    """
+    사용자의 특정 채팅방을 조회합니다. (삭제되지 않은 채팅방만)
+    """
+    return db.query(Chatroom).filter(
+        Chatroom.id == chatroom_id,
+        Chatroom.member_id == member_id,
+        Chatroom.is_deleted == False
+    ).first()
+
+
+@log_db_operation("SELECT")
+def get_chatrooms_by_member(db: Session, member_id: str) -> List[Chatroom]:
+    """
+    사용자의 모든 채팅방을 조회합니다. (삭제되지 않은 채팅방만)
+    """
+    return db.query(Chatroom).filter(
+        Chatroom.member_id == member_id,
+        Chatroom.is_deleted == False
+    ).order_by(Chatroom.created_at.desc()).all()
+
+
+@log_db_operation("INSERT")
+def create_chatroom(db: Session, member_id: str, data: ChatroomCreate) -> Chatroom:
+    """
+    새로운 채팅방을 생성합니다.
+    """
+    chatroom = Chatroom(
+        member_id=member_id,
+        title=data.title,
+        is_deleted=False
+    )
+    db.add(chatroom)
+    db.commit()
+    db.refresh(chatroom)
+    return chatroom
+
+
+@log_db_operation("UPDATE")
+def update_chatroom(db: Session, chatroom_id: int, member_id: str, data: ChatroomUpdate) -> Optional[Chatroom]:
+    """
+    채팅방 정보를 수정합니다.
+    """
+    chatroom = get_chatroom(db, chatroom_id, member_id)
+    if not chatroom:
+        return None
+    
+    if data.title is not None:
+        chatroom.title = data.title
+    
+    db.commit()
+    db.refresh(chatroom)
+    return chatroom
+
+
+@log_db_operation("UPDATE")
+def delete_chatroom(db: Session, chatroom_id: int, member_id: str) -> bool:
+    """
+    채팅방을 논리적으로 삭제합니다. (is_deleted = True)
+    """
+    chatroom = get_chatroom(db, chatroom_id, member_id)
+    if not chatroom:
+        return False
+    
+    chatroom.is_deleted = True
+    db.commit()
+    return True 

--- a/backend/src/db/models.py
+++ b/backend/src/db/models.py
@@ -169,3 +169,32 @@ class JobPosting(Base):
         secondary=job_posting_mapping,
         back_populates="job_postings"
     )
+
+
+class Chatroom(Base):
+    __tablename__ = "chat_room"
+    
+    id         = Column(Integer, primary_key=True, autoincrement=True)
+    member_id  = Column(String(36), ForeignKey("member.id"), nullable=False)
+    title      = Column(String(255), nullable=True)  # 채팅방 제목 (추가됨)
+    is_deleted = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+    
+    # ——— 채팅방-멤버 참조 ———
+    member = relationship("Member")
+    
+    # ——— 채팅방-메시지 참조 ———  
+    messages = relationship("ChatMessage", back_populates="chatroom", cascade="all, delete-orphan")
+
+
+class ChatMessage(Base):
+    __tablename__ = "chat_history"
+    
+    id           = Column(Integer, primary_key=True, autoincrement=True)
+    chat_room_id = Column(Integer, ForeignKey("chat_room.id"), nullable=False)
+    sender       = Column(Enum("user", "llm", name="sender_type"), nullable=False)
+    content      = Column(Text, nullable=True)
+    created_at   = Column(DateTime, nullable=False, server_default=func.now())
+    
+    # ——— 메시지-채팅방 참조 ———
+    chatroom = relationship("Chatroom", back_populates="messages")

--- a/backend/src/schemas/chatroom.py
+++ b/backend/src/schemas/chatroom.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+from typing import Optional, List
+from pydantic import BaseModel
+
+
+# ——— 채팅방 스키마 ———
+class ChatroomCreate(BaseModel):
+    """채팅방 생성 요청 스키마"""
+    title: Optional[str] = None  # 채팅방 제목 (선택적)
+
+
+class ChatroomRead(BaseModel):
+    """채팅방 조회 응답 스키마"""
+    id: int
+    member_id: str
+    title: Optional[str] = None
+    is_deleted: bool = False
+    created_at: datetime
+    
+    class Config:
+        from_attributes = True
+
+
+class ChatroomUpdate(BaseModel):
+    """채팅방 수정 요청 스키마"""
+    title: Optional[str] = None
+
+
+# ——— 채팅 메시지 스키마 ———
+class ChatMessageCreate(BaseModel):
+    """채팅 메시지 생성 요청 스키마"""
+    content: str
+    sender: str = "user"  # "user" 또는 "llm"
+
+
+class ChatMessageRead(BaseModel):
+    """채팅 메시지 조회 응답 스키마"""
+    id: int
+    chat_room_id: int
+    sender: str
+    content: Optional[str] = None
+    created_at: datetime
+    
+    class Config:
+        from_attributes = True
+
+
+# ——— 상세 채팅방 스키마 (메시지 포함) ———
+class ChatroomDetail(ChatroomRead):
+    """채팅방 상세 조회 응답 스키마 (메시지 포함)"""
+    messages: List[ChatMessageRead] = [] 


### PR DESCRIPTION
# What is this PR? 🔍

## ➕ 이슈 링크

- issue : #24

## ➕ 개요

채팅방 관련 API 작업입니다.

## ➕ 작업 내용

다음 API 작업 완료했습니다.

1. 채팅방 목록 조회 (로그인한 사용자의 삭제되지 않은 채팅방 목록만 조회됩니다.)
2. 채팅 히스토리 (특정 채팅방 안의 기존 채팅 이력을 조회합니다.)
3. 채팅방 생성
4. 채팅방 제목 수정 (상황에 따라 1차 개발(딥러닝 프로젝트)에서는 프론트에서 구현하지 않을 수 있습니다.)
5. 채팅방 삭제 (마찬가지로 1차 개발에서는 프론트에서 구현하지 않을 수 있습니다.)

사용자의 채팅을 LLM 서버로 넘겨주는 API는 LLM 서버의 API 작업이 우선시 되어야 할 듯 싶어서 아직 개발 안했습니다.
LLM 서버 API 작업하고, 백엔드 - LLM 서버 - Ingestion 서버 파이프라인이 구축이 되면 그때부터 프론트엔드 개발 시작할 듯 합니다.

