### PR TITLE
[FEAT] 챗봇 응답 API

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,3 +24,6 @@ pymysql
 
 # itsdangerous - 쿠키 서명 및 검증
 itsdangerous
+
+# HTTP 클라이언트 (LLM 서비스 통신용)
+httpx

--- a/backend/src/api/routers/chat.py
+++ b/backend/src/api/routers/chat.py
@@ -1,0 +1,102 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from datetime import datetime
+from typing import Dict, Any
+
+from schemas.chat import ChatRequest, ChatResponse
+from schemas.chatroom import ChatMessageCreate
+from crud.profile import get_profile
+from crud.chatroom import get_chatroom, create_chat_message
+from db.session import get_db
+from util.deps import get_current_user
+from util.logging import log_api_call
+from util.llm_client import LLMServiceClient
+from util.profile_converter import convert_profile_to_llm_format
+
+router = APIRouter(prefix="/chatrooms", tags=["chat"])
+
+
+@router.post("/{chatroom_id}/chat", response_model=ChatResponse)
+@log_api_call
+async def chat_with_llm(
+    chatroom_id: int,
+    request: ChatRequest,
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    채팅방에서 LLM과 대화합니다.
+    
+    1. 사용자 메시지를 DB에 저장
+    2. 사용자 프로필 조회 및 변환
+    3. LLM-service에 요청 전송
+    4. LLM 응답을 DB에 저장
+    5. 응답 반환
+    
+    Args:
+        chatroom_id: 채팅방 ID
+        request: 채팅 요청 (사용자 메시지)
+        
+    Returns:
+        ChatResponse: LLM 응답과 추천 채용공고
+    """
+    
+    # 1. 채팅방 존재 및 권한 확인
+    chatroom = get_chatroom(db, chatroom_id, current_user.id)
+    if not chatroom:
+        raise HTTPException(
+            status_code=404,
+            detail="채팅방을 찾을 수 없습니다."
+        )
+    
+    try:
+        # 2. 사용자 메시지를 DB에 저장
+        user_message_data = ChatMessageCreate(
+            content=request.message,
+            sender="user"
+        )
+        create_chat_message(db, chatroom_id, user_message_data)
+        
+        # 3. 사용자 프로필 조회
+        profile = get_profile(db, current_user.id)
+        if not profile:
+            raise HTTPException(
+                status_code=500,
+                detail="사용자 프로필을 찾을 수 없습니다."
+            )
+        
+        # 4. 프로필을 LLM-service 형식으로 변환
+        llm_profile = convert_profile_to_llm_format(profile, db)
+        
+        # 5. LLM-service에 요청 전송
+        llm_client = LLMServiceClient()
+        llm_response = await llm_client.generate_response(
+            query=request.message,
+            profile=llm_profile
+        )
+        
+        # 6. LLM 응답을 DB에 저장
+        llm_message_data = ChatMessageCreate(
+            content=llm_response.content,
+            sender="llm"
+        )
+        create_chat_message(db, chatroom_id, llm_message_data)
+        
+        # 7. 응답 반환
+        return ChatResponse(
+            user_message=request.message,
+            llm_response=llm_response.content,
+            recommended_jobs=llm_response.recommended_jobs,
+            created_at=datetime.now()
+        )
+        
+    except HTTPException:
+        # HTTPException은 그대로 재발생
+        raise
+        
+    except Exception as e:
+        # 기타 모든 예외는 500 에러로 처리
+        raise HTTPException(
+            status_code=500,
+            detail=f"채팅 처리 중 오류가 발생했습니다: {str(e)}"
+        ) 

--- a/backend/src/api/routers/chatroom.py
+++ b/backend/src/api/routers/chatroom.py
@@ -5,11 +5,13 @@ from typing import List
 from schemas.chatroom import (
     ChatroomCreate,
     ChatroomRead,
-    ChatroomUpdate
+    ChatroomUpdate,
+    ChatroomDetail
 )
 from crud.chatroom import (
     create_chatroom,
     get_chatroom,
+    get_chatroom_with_messages,
     get_chatrooms_by_member,
     update_chatroom,
     delete_chatroom
@@ -50,7 +52,7 @@ def get_my_chatrooms(
     return get_chatrooms_by_member(db, current_user.id)
 
 
-@router.get("/{chatroom_id}", response_model=ChatroomRead)
+@router.get("/{chatroom_id}", response_model=ChatroomDetail)
 @log_api_call
 def get_chatroom_detail(
     chatroom_id: int,
@@ -58,9 +60,9 @@ def get_chatroom_detail(
     db: Session = Depends(get_db)
 ):
     """
-    특정 채팅방의 정보를 조회합니다.
+    특정 채팅방의 정보와 메시지를 조회합니다.
     """
-    chatroom = get_chatroom(db, chatroom_id, current_user.id)
+    chatroom = get_chatroom_with_messages(db, chatroom_id, current_user.id)
     if not chatroom:
         raise HTTPException(
             status_code=404,

--- a/backend/src/backend.py
+++ b/backend/src/backend.py
@@ -4,7 +4,7 @@ from sqlalchemy import text
 from starlette.middleware.sessions import SessionMiddleware
 
 from config.config import settings
-from api.routers import user, profile, course, chatroom
+from api.routers import user, profile, course, chatroom, chat
 from db.session import get_db
 from util.logging import setup_logging
 
@@ -17,6 +17,7 @@ app.include_router(user.router)
 app.include_router(profile.router)
 app.include_router(course.router)
 app.include_router(chatroom.router)
+app.include_router(chat.router)
 
 @app.get("/")
 def root():

--- a/backend/src/config/config.py
+++ b/backend/src/config/config.py
@@ -16,5 +16,8 @@ class Settings:
     DB_NAME: str = os.getenv("DB_NAME")
     SECRET_KEY: str = os.getenv("SECRET_KEY", "replace-with-your-secret")
     
+    # LLM Service 설정
+    LLM_SERVICE_URL: str = os.getenv("LLM_SERVICE_URL")
+    LLM_REQUEST_TIMEOUT: float = 30.0
 
 settings = Settings()

--- a/backend/src/crud/chatroom.py
+++ b/backend/src/crud/chatroom.py
@@ -20,6 +20,22 @@ def get_chatroom(db: Session, chatroom_id: int, member_id: str) -> Optional[Chat
 
 
 @log_db_operation("SELECT")
+def get_chatroom_with_messages(db: Session, chatroom_id: int, member_id: str) -> Optional[Chatroom]:
+    """
+    사용자의 특정 채팅방을 메시지와 함께 조회합니다. (삭제되지 않은 채팅방만)
+    """
+    from sqlalchemy.orm import joinedload
+    
+    return db.query(Chatroom).options(
+        joinedload(Chatroom.messages)
+    ).filter(
+        Chatroom.id == chatroom_id,
+        Chatroom.member_id == member_id,
+        Chatroom.is_deleted == False
+    ).first()
+
+
+@log_db_operation("SELECT")
 def get_chatrooms_by_member(db: Session, member_id: str) -> List[Chatroom]:
     """
     사용자의 모든 채팅방을 조회합니다. (삭제되지 않은 채팅방만)

--- a/backend/src/crud/chatroom.py
+++ b/backend/src/crud/chatroom.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from typing import List, Optional
 
 from db.models import Chatroom, ChatMessage
-from schemas.chatroom import ChatroomCreate, ChatroomUpdate
+from schemas.chatroom import ChatroomCreate, ChatroomUpdate, ChatMessageCreate
 from util.logging import log_db_operation
 
 
@@ -44,6 +44,22 @@ def create_chatroom(db: Session, member_id: str, data: ChatroomCreate) -> Chatro
     db.commit()
     db.refresh(chatroom)
     return chatroom
+
+
+@log_db_operation("INSERT")
+def create_chat_message(db: Session, chatroom_id: int, data: ChatMessageCreate) -> ChatMessage:
+    """
+    채팅방에 새로운 메시지를 추가합니다.
+    """
+    message = ChatMessage(
+        chat_room_id=chatroom_id,
+        sender=data.sender,
+        content=data.content
+    )
+    db.add(message)
+    db.commit()
+    db.refresh(message)
+    return message
 
 
 @log_db_operation("UPDATE")

--- a/backend/src/schemas/chat.py
+++ b/backend/src/schemas/chat.py
@@ -1,0 +1,39 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional
+from datetime import datetime
+
+
+class ChatRequest(BaseModel):
+    """채팅 요청 스키마"""
+    message: str = Field(..., description="사용자 메시지")
+
+
+class RecommendedJob(BaseModel):
+    """추천된 채용공고"""
+    rec_idx: Optional[str] = None  
+    title: str
+    url: str
+    deadline: Optional[str] = None
+    start_date: Optional[str] = None  
+    crawling_time: Optional[str] = None  
+    recommendation_reason: str
+
+
+class ChatResponse(BaseModel):
+    """채팅 응답 스키마"""
+    user_message: str = Field(..., description="사용자가 보낸 메시지")
+    llm_response: str = Field(..., description="LLM 응답 내용")
+    recommended_jobs: List[RecommendedJob] = Field(default=[], description="추천된 채용 공고 목록")
+    created_at: datetime = Field(..., description="응답 생성 시간")
+
+
+class LLMServiceRequest(BaseModel):
+    """LLM 서비스로 보낼 요청 스키마"""
+    query: str = Field(..., description="사용자 질문")
+    profile: dict = Field(..., description="사용자 프로필")
+
+
+class LLMServiceResponse(BaseModel):
+    """LLM 서비스로부터 받을 응답 스키마"""
+    content: str
+    recommended_jobs: List[RecommendedJob] = Field(default=[], description="추천된 채용 공고 목록") 

--- a/backend/src/util/llm_client.py
+++ b/backend/src/util/llm_client.py
@@ -1,0 +1,62 @@
+import httpx
+import logging
+from typing import Dict, Any
+from config.config import settings
+from schemas.chat import LLMServiceRequest, LLMServiceResponse
+
+logger = logging.getLogger(__name__)
+
+
+class LLMServiceClient:
+    """LLM 서비스와 통신하는 클라이언트"""
+    
+    def __init__(self):
+        self.base_url = settings.LLM_SERVICE_URL
+        self.timeout = settings.LLM_REQUEST_TIMEOUT
+    
+    async def generate_response(self, query: str, profile: Dict[str, Any]) -> LLMServiceResponse:
+        """
+        LLM 서비스에 요청을 보내고 응답을 받습니다.
+        
+        Args:
+            query: 사용자 질문
+            profile: 사용자 프로필 정보
+            
+        Returns:
+            LLMServiceResponse: LLM 서비스 응답
+            
+        Raises:
+            Exception: LLM 서비스 호출 실패 시
+        """
+        request_data = LLMServiceRequest(query=query, profile=profile)
+        url = f"{self.base_url}/generate-llm"
+        
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                logger.info(f"LLM 서비스 요청: {url}")
+                logger.debug(f"요청 데이터: {request_data.model_dump()}")
+                
+                response = await client.post(
+                    url,
+                    json=request_data.model_dump(),
+                    headers={"Content-Type": "application/json"}
+                )
+                response.raise_for_status()
+                
+                response_data = response.json()
+                logger.info("LLM 서비스 응답 수신 완료")
+                logger.debug(f"응답 데이터: {response_data}")
+                
+                return LLMServiceResponse(**response_data)
+                
+        except httpx.TimeoutException:
+            logger.error(f"LLM 서비스 요청 타임아웃: {self.timeout}초")
+            raise Exception("LLM 서비스 응답 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.")
+            
+        except httpx.HTTPStatusError as e:
+            logger.error(f"LLM 서비스 HTTP 에러: {e.response.status_code}")
+            raise Exception(f"LLM 서비스에서 오류가 발생했습니다: {e.response.status_code}")
+            
+        except Exception as e:
+            logger.error(f"LLM 서비스 호출 중 예상치 못한 오류: {str(e)}")
+            raise Exception("LLM 서비스 호출 중 오류가 발생했습니다. 관리자에게 문의해주세요.") 

--- a/backend/src/util/llm_client.py
+++ b/backend/src/util/llm_client.py
@@ -48,14 +48,6 @@ class LLMServiceClient:
                 logger.debug(f"응답 데이터: {response_data}")
                 
                 return LLMServiceResponse(**response_data)
-                
-        except httpx.TimeoutException:
-            logger.error(f"LLM 서비스 요청 타임아웃: {self.timeout}초")
-            raise Exception("LLM 서비스 응답 시간이 초과되었습니다. 잠시 후 다시 시도해주세요.")
-            
-        except httpx.HTTPStatusError as e:
-            logger.error(f"LLM 서비스 HTTP 에러: {e.response.status_code}")
-            raise Exception(f"LLM 서비스에서 오류가 발생했습니다: {e.response.status_code}")
             
         except Exception as e:
             logger.error(f"LLM 서비스 호출 중 예상치 못한 오류: {str(e)}")

--- a/backend/src/util/profile_converter.py
+++ b/backend/src/util/profile_converter.py
@@ -1,0 +1,115 @@
+from typing import Dict, List, Any, Optional
+from sqlalchemy.orm import Session
+from schemas.profile import ProfileRead
+from db.models import CourseCatalog
+from util.logging import log_db_operation
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def convert_profile_to_llm_format(profile: ProfileRead, db: Session) -> Dict[str, Any]:
+    """
+    백엔드 프로필을 LLM-service 요청 형식으로 변환합니다.
+    
+    Args:
+        profile: 백엔드 프로필 데이터
+        db: SQLAlchemy 세션
+        
+    Returns:
+        Dict: LLM-service RetrievalRequest 형식의 딕셔너리
+    """
+    try:
+        # 1. major: department를 major로 매핑
+        major = profile.department or "미지정"
+        
+        # 2. catalogs: course_catalogs를 CourseInfo 형식으로 변환
+        catalogs = _convert_course_catalogs(profile.course_catalogs, db)
+        
+        # 3. interest_job: job_interests를 문자열 리스트로 변환
+        interest_job = [job.interest for job in profile.job_interests]
+        
+        # 4. certification: certifications를 문자열 리스트로 변환
+        certification = [cert.content for cert in profile.certifications if cert.content]
+        
+        result = {
+            "major": major,
+            "catalogs": catalogs,
+            "interest_job": interest_job,
+            "certification": certification
+        }
+        
+        logger.info(f"프로필 변환 완료: 전공={major}, 과목수={len(catalogs)}, 관심직무수={len(interest_job)}, 자격증수={len(certification)}")
+        return result
+        
+    except Exception as e:
+        logger.error(f"프로필 변환 중 오류 발생: {str(e)}")
+        raise Exception("프로필 데이터 변환 중 오류가 발생했습니다.")
+
+
+@log_db_operation("SELECT")
+def _convert_course_catalogs(course_catalogs: List, db: Session) -> List[Dict[str, Any]]:
+    """
+    수강 과목 목록을 CourseInfo 형식으로 변환합니다.
+    
+    Args:
+        course_catalogs: 백엔드 CourseCatalogRead 리스트
+        db: SQLAlchemy 세션
+        
+    Returns:
+        List[Dict]: CourseInfo 형식의 딕셔너리 리스트
+    """
+    result = []
+    
+    for course_catalog in course_catalogs:
+        try:
+            # DB에서 상세 Course 정보 조회
+            course_detail = db.query(CourseCatalog).filter(
+                CourseCatalog.id == course_catalog.id
+            ).first()
+            
+            if course_detail:
+                course_info = _create_course_info_dict(course_detail)
+                result.append(course_info)
+            else:
+                logger.warning(f"Course ID {course_catalog.id}에 대한 상세 정보를 찾을 수 없습니다.")
+                
+        except Exception as e:
+            logger.error(f"Course ID {course_catalog.id} 변환 중 오류: {str(e)}")
+            continue
+    
+    return result
+
+
+def _create_course_info_dict(course: CourseCatalog) -> Dict[str, Any]:
+    """
+    CourseCatalog 모델을 CourseInfo 딕셔너리로 변환합니다.
+    
+    Args:
+        course: CourseCatalog 모델 인스턴스
+        
+    Returns:
+        Dict: CourseInfo 형식의 딕셔너리
+    """
+    return {
+        "course_name": course.course_name or "",
+        "core_competency": course.core_competency or "",
+        "course_overview": course.course_overview or "",
+        "course_objectives": course.course_objectives or "",
+        "week1_plan": course.week1_plan or "",
+        "week2_plan": course.week2_plan or "",
+        "week3_plan": course.week3_plan or "",
+        "week4_plan": course.week4_plan or "",
+        "week5_plan": course.week5_plan or "",
+        "week6_plan": course.week6_plan or "",
+        "week7_plan": course.week7_plan or "",
+        "week8_plan": course.week8_plan or "",
+        "week9_plan": course.week9_plan or "",
+        "week10_plan": course.week10_plan or "",
+        "week11_plan": course.week11_plan or "",
+        "week12_plan": course.week12_plan or "",
+        "week13_plan": course.week13_plan or "",
+        "week14_plan": course.week14_plan or "",
+        "week15_plan": course.week15_plan or "",
+        "week16_plan": course.week16_plan or "",
+    } 

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,11 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "dev": false
+    }
+  },
+  "github": {
+    "autoAlias": false
+  }
+} 


### PR DESCRIPTION
# What is this PR? 🔍

## ➕ 이슈 링크

- issue : #63

## ➕ 개요

사용자의 인풋과 사용자에 맞는 프로필 정보를 조회하여 llm 서버의 출력 api에 요청값으로 넘기는 api 작업입니다.

## ➕ 작업 내용

사용자의 채팅, 챗봇의 응답 모두 DB에 저장하여 채팅 히스토리를 관리합니다. (채팅방 접속시 과거의 채팅 이력을 출력하기 위함입니다.)
추가적으로 채팅방 상세 api에서 채팅 히스토리를 반환하고있지 않길래 수정 작업 했습니다.

