### PR TITLE
[FEAT] 순수한 카탈로그 데이터와 사용자의 인풋을 검색 쿼리로 사용

### DIFF
--- a/backend/src/api/routers/chat.py
+++ b/backend/src/api/routers/chat.py
@@ -6,7 +6,7 @@ from typing import Dict, Any
 from schemas.chat import ChatRequest, ChatResponse
 from schemas.chatroom import ChatMessageCreate
 from crud.profile import get_profile
-from crud.chatroom import get_chatroom, create_chat_message
+from crud.chatroom import get_chatroom, create_chat_message, get_recent_chat_messages
 from db.session import get_db
 from util.deps import get_current_user
 from util.logging import log_api_call
@@ -29,9 +29,10 @@ async def chat_with_llm(
     
     1. 사용자 메시지를 DB에 저장
     2. 사용자 프로필 조회 및 변환
-    3. LLM-service에 요청 전송
-    4. LLM 응답을 DB에 저장
-    5. 응답 반환
+    3. 최근 대화 이력 조회
+    4. LLM-service에 요청 전송
+    5. LLM 응답을 DB에 저장
+    6. 응답 반환
     
     Args:
         chatroom_id: 채팅방 ID
@@ -68,14 +69,22 @@ async def chat_with_llm(
         # 4. 프로필을 LLM-service 형식으로 변환
         llm_profile = convert_profile_to_llm_format(profile, db)
         
-        # 5. LLM-service에 요청 전송
+        # 5. 최근 대화 이력 조회
+        recent_messages = get_recent_chat_messages(db, chatroom_id, limit=5)
+        chat_history = [
+            {"role": msg.sender, "content": msg.content}
+            for msg in recent_messages
+        ]
+        
+        # 6. LLM-service에 요청 전송
         llm_client = LLMServiceClient()
         llm_response = await llm_client.generate_response(
             query=request.message,
-            profile=llm_profile
+            profile=llm_profile,
+            chat_history=chat_history  # 대화 이력 추가
         )
         
-        # 6. LLM 응답을 DB에 저장
+        # 7. LLM 응답을 DB에 저장
         llm_message_data = ChatMessageCreate(
             content=llm_response.content,
             sender="llm",
@@ -83,7 +92,7 @@ async def chat_with_llm(
         )
         create_chat_message(db, chatroom_id, llm_message_data)
         
-        # 7. 응답 반환
+        # 8. 응답 반환
         return ChatResponse(
             user_message=request.message,
             llm_response=llm_response.content,

--- a/backend/src/crud/chatroom.py
+++ b/backend/src/crud/chatroom.py
@@ -107,4 +107,30 @@ def delete_chatroom(db: Session, chatroom_id: int, member_id: str) -> bool:
     
     chatroom.is_deleted = True
     db.commit()
-    return True 
+    return True
+
+
+@log_db_operation("SELECT")
+def get_recent_chat_messages(
+    db: Session, 
+    chatroom_id: int, 
+    limit: int = 5
+) -> List[ChatMessage]:
+    """
+    채팅방의 최근 메시지들을 조회합니다.
+    
+    Args:
+        db: 데이터베이스 세션
+        chatroom_id: 채팅방 ID
+        limit: 조회할 최근 메시지 수 (기본값: 5)
+        
+    Returns:
+        List[ChatMessage]: 최근 메시지 목록 (시간순 정렬)
+    """
+    messages = db.query(ChatMessage).filter(
+        ChatMessage.chat_room_id == chatroom_id
+    ).order_by(
+        ChatMessage.created_at.desc()
+    ).limit(limit).all()
+    
+    return list(reversed(messages))  # 시간순 정렬하여 반환 

--- a/backend/src/util/llm_client.py
+++ b/backend/src/util/llm_client.py
@@ -1,8 +1,9 @@
 import httpx
 import logging
-from typing import Dict, Any
+from typing import Dict, Any, List, Optional
 from config.config import settings
 from schemas.chat import LLMServiceRequest, LLMServiceResponse
+from fastapi import HTTPException
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +15,62 @@ class LLMServiceClient:
         self.base_url = settings.LLM_SERVICE_URL
         self.timeout = settings.LLM_REQUEST_TIMEOUT
     
-    async def generate_response(self, query: str, profile: Dict[str, Any]) -> LLMServiceResponse:
+    async def generate_response(
+        self, 
+        query: str, 
+        profile: Dict,
+        chat_history: Optional[List[Dict[str, str]]] = None
+    ) -> LLMServiceResponse:
+        """
+        LLM 서비스에 요청을 보내 응답을 생성합니다.
+        
+        Args:
+            query: 사용자 질문
+            profile: 사용자 프로필
+            chat_history: 대화 이력 (선택적)
+            
+        Returns:
+            LLMServiceResponse: LLM 응답과 추천 채용공고
+        """
+        try:
+            # 대화 이력 로깅
+            if chat_history:
+                logger.info(f"📝 전달되는 대화 이력 (최근 {len(chat_history)}개):")
+                for msg in chat_history:
+                    logger.info(f"  - {msg['role']}: {msg['content'][:50]}...")
+            else:
+                logger.info("❌ 전달되는 대화 이력 없음")
+
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    f"{self.base_url}/generate-llm",
+                    json={
+                        "query": query,
+                        "profile": profile,
+                        "chat_history": chat_history
+                    },
+                    timeout=30.0
+                )
+                
+                if response.status_code != 200:
+                    raise HTTPException(
+                        status_code=503,
+                        detail="LLM 서비스 응답 오류"
+                    )
+                
+                response_data = response.json()
+                return LLMServiceResponse(
+                    content=response_data["content"],
+                    recommended_jobs=response_data["recommended_jobs"]
+                )
+                
+        except httpx.RequestError:
+            raise HTTPException(
+                status_code=503,
+                detail="LLM 서비스에 연결할 수 없습니다."
+            )
+            
+    async def generate_response_old(self, query: str, profile: Dict[str, Any]) -> LLMServiceResponse:
         """
         LLM 서비스에 요청을 보내고 응답을 받습니다.
         

--- a/ingestion/src/api/models.py
+++ b/ingestion/src/api/models.py
@@ -47,6 +47,7 @@ class RetrievalRequest(BaseModel):
     catalogs: List[CourseInfo]
     interest_job: List[str]
     certification: List[str]
+    query: Optional[str] = None  # 사용자 질문 (선택적)
 
 
 class RetrievalResponse(BaseModel):

--- a/ingestion/src/api/routes.py
+++ b/ingestion/src/api/routes.py
@@ -45,6 +45,7 @@ async def retrieve_documents(request: RetrievalRequest) -> RetrievalResponse:
             catalogs=request.catalogs,
             interest_job=request.interest_job,
             certification=request.certification,
+            query=request.query,  # 사용자 질문 추가
         )
 
         # 2. ChromaDB에서 유사 문서 검색

--- a/ingestion/src/services/query_builder.py
+++ b/ingestion/src/services/query_builder.py
@@ -1,7 +1,7 @@
 """
 사용자 프로필 기반 검색 쿼리 생성 모듈
 """
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from api.models import CourseInfo  # CourseInfo 모델 import 추가
 
 
@@ -13,7 +13,8 @@ class ProfileQueryBuilder:
         major: str, 
         catalogs: List[CourseInfo],  # 타입 힌트를 CourseInfo로 변경
         interest_job: List[str], 
-        certification: List[str]
+        certification: List[str],
+        query: Optional[str] = None  # 사용자 질문 추가
     ) -> str:
         """
         사용자 프로필 기반 검색 쿼리 생성
@@ -23,11 +24,16 @@ class ProfileQueryBuilder:
             catalogs: 강의 목록 (CourseInfo 객체 리스트)
             interest_job: 관심 직무 목록  
             certification: 자격증 목록
+            query: 사용자 질문 (선택적)
             
         Returns:
             str: 생성된 검색 쿼리
         """
         query_parts = []
+
+        # 사용자 질문 추가 (있는 경우 최상단에 배치)
+        if query:
+            query_parts.append(f"질문: {query}")
 
         # 전공 정보 추가
         if major:

--- a/ingestion/src/services/query_builder.py
+++ b/ingestion/src/services/query_builder.py
@@ -2,6 +2,7 @@
 사용자 프로필 기반 검색 쿼리 생성 모듈
 """
 from typing import List, Dict, Any
+from api.models import CourseInfo  # CourseInfo 모델 import 추가
 
 
 class ProfileQueryBuilder:
@@ -10,7 +11,7 @@ class ProfileQueryBuilder:
     @staticmethod
     def create_profile_query(
         major: str, 
-        catalogs: List[Dict[str, Any]], 
+        catalogs: List[CourseInfo],  # 타입 힌트를 CourseInfo로 변경
         interest_job: List[str], 
         certification: List[str]
     ) -> str:
@@ -19,7 +20,7 @@ class ProfileQueryBuilder:
         
         Args:
             major: 전공
-            catalogs: 강의 목록
+            catalogs: 강의 목록 (CourseInfo 객체 리스트)
             interest_job: 관심 직무 목록  
             certification: 자격증 목록
             
@@ -40,14 +41,27 @@ class ProfileQueryBuilder:
         if certification:
             query_parts.append(f"자격증: {', '.join(certification)}")
 
-        # 강의 정보에서 핵심 키워드 추출
-        course_keywords = set()
-        for course in catalogs:
-            # 강의명과 핵심역량에서 키워드 추출
-            course_keywords.update(course.course_name.split())
-            course_keywords.update(course.core_competency.split())
-
-        if course_keywords:
-            query_parts.append(f"관련 키워드: {' '.join(course_keywords)}")
+        # 강의 정보 전체 추가
+        if catalogs:
+            query_parts.append("수강 이력:")
+            for course in catalogs:
+                # 각 강의의 모든 정보를 구조화하여 추가
+                course_parts = []
+                course_parts.append(f"강의명: {course.course_name}")
+                course_parts.append(f"핵심 역량: {course.core_competency}")
+                course_parts.append(f"강의 개요: {course.course_overview}")
+                course_parts.append(f"학습 목표: {course.course_objectives}")
+                
+                # 주차별 계획 추가
+                week_plans = []
+                for i in range(1, 17):  # 1주차부터 16주차까지
+                    week_plan = getattr(course, f'week{i}_plan')
+                    week_plans.append(f"{i}주차: {week_plan}")
+                
+                course_parts.append(f"주차별 계획: {' / '.join(week_plans)}")
+                
+                # 강의 정보들을 구분자로 구분하여 추가
+                query_parts.append(" | ".join(course_parts))
         
-        return " ".join(query_parts) 
+        # 모든 부분을 줄바꿈으로 구분하여 하나의 문자열로 결합
+        return "\n".join(query_parts) 

--- a/llm-service/src/api/models.py
+++ b/llm-service/src/api/models.py
@@ -51,6 +51,7 @@ class LLMRequest(BaseModel):
 
     query: str = Field(..., description="사용자 질문")
     profile: RetrievalRequest = Field(..., description="사용자 프로필")
+    chat_history: Optional[List[Dict[str, str]]] = None  # [{"role": "user/llm", "content": "메시지"}]
 
 
 class RecommendedJob(BaseModel):

--- a/llm-service/src/api/routes.py
+++ b/llm-service/src/api/routes.py
@@ -47,10 +47,13 @@ router = APIRouter()
 async def generate_llm_response(request: LLMRequest):
     """LLM 응답을 생성합니다."""
     try:
+        # 프로필에 query 설정 (Pydantic copy 메서드 사용)
+        profile_with_query = request.profile.copy(update={'query': request.query})
+
         # Ingestion 서비스에서 관련 문서 검색
         ingestion_client = IngestionClient()
         relevant_docs = await ingestion_client.retrieve_documents(
-            request.profile
+            profile_with_query
         )
 
         # LLM 서비스로 응답 생성
@@ -58,7 +61,7 @@ async def generate_llm_response(request: LLMRequest):
         response = await llm_service.generate_response(
             query=request.query, 
             documents=relevant_docs,
-            profile=request.profile
+            profile=profile_with_query
         )
 
         return response

--- a/llm-service/src/services/llm_prompting.py
+++ b/llm-service/src/services/llm_prompting.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from langchain_openai import ChatOpenAI
 from pydantic import BaseModel, Field
 from ..api.models import (
@@ -47,33 +47,58 @@ class LLMPromptingService:
         self.client = Client()
         self.tracer = LangChainTracer(project_name="career-hi-rag")
 
-    async def _classify_query_intent(self, query: str) -> str:
+    async def _classify_query_intent(self, query: str, chat_history: Optional[List[Dict[str, str]]] = None) -> str:
         """LLM을 이용해 질문의 의도를 3가지로 분류합니다."""
         try:
             logger.info(f"🔍 의도 분류 시작 - 질문: '{query}'")
             
+            # 대화 이력 로깅
+            if chat_history:
+                logger.info(f"📝 의도 분류에 사용되는 대화 이력 (최근 {len(chat_history[-2:])}개):")
+                for msg in chat_history[-2:]:
+                    logger.info(f"  - {msg['role']}: {msg['content']}")
+            
+            # 대화 이력 포맷팅
+            history_text = ""
+            if chat_history:
+                history_text = "\n".join([
+                    f"{msg['role']}: {msg['content']}"
+                    for msg in chat_history[-2:]  # 최근 2개 메시지만 사용
+                ])
+                history_text = f"\n최근 대화 내용:\n{history_text}\n"
+            
             classification_prompt = f"""
+                {history_text}
                 질문을 다음 3가지 중 하나로 분류해주세요:
 
-                1. REJECT: 취업/채용과 무관한 질문
-                예시: 날씨, 맛집, 일반 지식, 수학 문제 등
+                1. REJECT: 취업/채용과 전혀 무관한 질문
+                예시: 
+                - "오늘 날씨 어때?"
+                - "맛집 추천해줘"
+                - "2+2는 뭐야?"
+                - 취업, 채용, 경력과 완전히 관련 없는 주제
 
-                2. SEARCH_NEEDED: 채용공고 검색이 필요한 질문
+                2. SEARCH_NEEDED: 새로운 채용공고 검색이 필요한 질문
                 예시: 
                 - "추천 채용공고 알려줘"
                 - "백엔드 개발자 채용 정보 찾아줘"
                 - "○○ 회사 채용 있어?"
                 - "신입 개발자 공고 추천해줘"
+                - 새로운 채용공고를 찾아야 하는 질문들
 
-                3. NO_SEARCH: 일반적인 취업 상담 (문서 검색 불필요)
+                3. NO_SEARCH: 검색이 필요없는 취업 관련 질문
                 예시:
-                - "자기소개서 작성법"
-                - "면접 준비 방법"
-                - "기술 스택 공부 순서"
-                - "포트폴리오 만드는 법"
-                - "경력 개발 조언"
+                - "자기소개서 작성법 알려줘"
+                - "면접 준비 방법 알려줘"
+                - "이전에 추천해준 공고에 대해 더 자세히 설명해줘"
+                - "방금 추천한 첫 번째 공고는 어떤 공고야?"
+                - "그 회사 면접은 어떻게 준비하면 좋을까?"
+                - 기존 추천에 대한 추가 질문
+                - 일반적인 취업 상담 질문
 
-                질문: {query}
+                중요: 이전 추천 채용공고에 대한 추가 질문은 새로운 검색이 필요없으므로 NO_SEARCH로 분류하세요.
+                
+                사용자 질문: {query}
 
                 답변: REJECT, SEARCH_NEEDED, NO_SEARCH 중 하나만
                 """
@@ -95,13 +120,13 @@ class LLMPromptingService:
                 logger.info(f"💬 의도 분류 결과: NO_SEARCH - 일반 취업 상담")
                 return "NO_SEARCH"
             else:
-                # 애매한 경우 안전하게 검색 진행
-                logger.warning(f"⚠️ 의도 분류 결과가 애매함: '{result}' -> SEARCH_NEEDED로 처리")
-                return "SEARCH_NEEDED"
+                # 애매한 경우 NO_SEARCH로 처리
+                logger.warning(f"⚠️ 의도 분류 결과가 애매함: '{result}' -> NO_SEARCH로 처리")
+                return "NO_SEARCH"
             
         except Exception as e:
-            logger.warning(f"💥 의도 분류 실패, 안전하게 SEARCH_NEEDED로 처리: {e}")
-            return "SEARCH_NEEDED"
+            logger.warning(f"💥 의도 분류 실패, 안전하게 NO_SEARCH로 처리: {e}")
+            return "NO_SEARCH"
 
     def _extract_recommended_jobs_from_function_call(
         self, function_args: Dict[str, Any], documents: List[JobPosting]
@@ -161,8 +186,47 @@ class LLMPromptingService:
 
         return recommended_jobs
 
+    def _create_prompt(
+        self, 
+        query: str, 
+        documents: List[str],
+        profile: Dict,
+        chat_history: Optional[List[Dict[str, str]]] = None
+    ) -> str:
+        """프롬프트 생성"""
+        
+        # 대화 이력 포맷팅
+        history_text = ""
+        if chat_history:
+            history_text = "\n".join([
+                f"{msg['role']}: {msg['content']}"
+                for msg in chat_history[-5:]  # 최근 5개 메시지만 사용
+            ])
+            history_text = f"\n이전 대화 내용:\n{history_text}\n"
+
+        # 문서 컨텍스트 포맷팅
+        docs_text = "\n---\n".join(documents) if documents else "관련 문서가 없습니다."
+        
+        return f"""당신은 Career-Hi의 AI 커리어 어시스턴트입니다.
+            사용자의 프로필과 질문을 바탕으로 커리어 관련 조언을 제공해주세요.
+
+            {history_text}
+            사용자 프로필:
+            {profile}
+
+            관련 문서:
+            {docs_text}
+
+            사용자 질문: {query}
+
+            답변:"""
+
     async def generate_response(
-        self, query: str, documents: List[JobPosting], profile: RetrievalRequest
+        self, 
+        query: str, 
+        documents: List[JobPosting],
+        profile: RetrievalRequest,
+        chat_history: Optional[List[Dict[str, str]]] = None
     ) -> LLMResponse:
         """사용자 질문에 대한 응답을 생성합니다."""
         try:
@@ -170,7 +234,7 @@ class LLMPromptingService:
             logger.info(f"📊 검색된 문서 수: {len(documents)}")
             
             # 1단계: LLM으로 질문 의도 분류 (토큰 절약을 위한 간단한 프롬프트)
-            intent = await self._classify_query_intent(query)
+            intent = await self._classify_query_intent(query, chat_history)
             
             if intent == "REJECT":
                 logger.info(f"🚫 REJECT 경로 - 거부 응답 반환")
@@ -182,23 +246,31 @@ class LLMPromptingService:
             elif intent == "NO_SEARCH":
                 logger.info(f"💬 NO_SEARCH 경로 - 일반 상담 응답 생성")
                 # 문서 검색 없이 일반 취업 상담 응답 생성
-                return await self._generate_consultation_response(query, profile)
+                response = await self._generate_consultation_response(query, profile, chat_history)
+                return LLMResponse(**response)
             
             elif intent == "SEARCH_NEEDED":
                 logger.info(f"🔍 SEARCH_NEEDED 경로 - 채용공고 추천 응답 생성")
-                # 기존 로직: 문서 검색 + 채용공고 추천
-                return await self._generate_recommendation_response(query, documents, profile)
+                # 기존 로직: 문서 검색
+                response = await self._generate_recommendation_response(query, documents, profile, chat_history)
+                return LLMResponse(**response)
             
             else:
                 logger.warning(f"⚠️ 예상치 못한 의도: '{intent}' - SEARCH_NEEDED로 처리")
                 # 예상치 못한 경우, 안전하게 검색 진행
-                return await self._generate_recommendation_response(query, documents, profile)
+                response = await self._generate_recommendation_response(query, documents, profile, chat_history)
+                return LLMResponse(**response)
 
         except Exception as e:
             logger.error(f"💥 LLM 응답 생성 중 오류: {str(e)}")
             raise
 
-    async def _generate_consultation_response(self, query: str, profile: RetrievalRequest) -> LLMResponse:
+    async def _generate_consultation_response(
+        self, 
+        query: str, 
+        profile: RetrievalRequest,
+        chat_history: Optional[List[Dict[str, str]]] = None
+    ) -> Dict:
         """문서 검색 없이 일반 취업 상담 응답을 생성합니다."""
         try:
             # 사용자 프로필 정보 정리
@@ -209,10 +281,19 @@ class LLMPromptingService:
 - 자격증: {', '.join(profile.certification)}
 - 수강 과목: {', '.join([course.course_name for course in profile.catalogs[:5]])}{"..." if len(profile.catalogs) > 5 else ""}
 """
+            # 대화 이력 포맷팅
+            history_text = ""
+            if chat_history:
+                history_text = "\n".join([
+                    f"{msg['role']}: {msg['content']}"
+                    for msg in chat_history[-5:]  # 최근 5개 메시지만 사용
+                ])
+                history_text = f"\n이전 대화 내용:\n{history_text}\n"
             
             consultation_prompt = f"""
 당신은 취업 상담 전문가입니다. 사용자의 프로필을 고려하여 실용적이고 도움이 되는 조언을 제공해주세요.
 
+{history_text}
 {profile_summary}
 
 사용자 질문: {query}
@@ -233,16 +314,22 @@ class LLMPromptingService:
             
             response = await self.llm.ainvoke(consultation_prompt)
             
-            return LLMResponse(
-                content=response.content.strip(),
-                recommended_jobs=[]  # 상담에는 채용공고 추천 없음
-            )
+            return {
+                "content": response.content.strip(),
+                "recommended_jobs": []  # 상담에는 채용공고 추천 없음
+            }
             
         except Exception as e:
             logger.error(f"상담 응답 생성 실패: {str(e)}")
             raise
 
-    async def _generate_recommendation_response(self, query: str, documents: List[JobPosting], profile: RetrievalRequest) -> LLMResponse:
+    async def _generate_recommendation_response(
+        self, 
+        query: str, 
+        documents: List[JobPosting], 
+        profile: RetrievalRequest,
+        chat_history: Optional[List[Dict[str, str]]] = None
+    ) -> Dict:
         """문서 검색 기반 채용공고 추천 응답을 생성합니다."""
         try:
             # 사용자 프로필 정보 정리
@@ -253,6 +340,15 @@ class LLMPromptingService:
 - 자격증: {', '.join(profile.certification)}
 - 수강 과목: {', '.join([course.course_name for course in profile.catalogs[:5]])}{"..." if len(profile.catalogs) > 5 else ""}
 """
+            # 대화 이력 포맷팅
+            history_text = ""
+            if chat_history:
+                history_text = "\n".join([
+                    f"{msg['role']}: {msg['content']}"
+                    for msg in chat_history[-5:]  # 최근 5개 메시지만 사용
+                ])
+                history_text = f"\n이전 대화 내용:\n{history_text}\n"
+                logger.info(f"📝 추천 응답 생성에 사용되는 대화 이력:\n{history_text}")
             
             # 문서 포맷팅
             doc_texts = [
@@ -263,8 +359,9 @@ class LLMPromptingService:
 
             # 프롬프트 템플릿 생성 (채용공고 추천 전용)
             prompt = f"""
-당신은 취업 상담 전문가입니다. 사용자의 프로필과 질문에 맞춰 적절한 채용공고를 추천해주세요.
+당신은 취업 상담 전문가입니다. 사용자의 프로필과 질문에 맞춰 적절한 채용공고를 추천하거나 이전 추천에 대해 설명해주세요.
 
+{history_text}
 {profile_summary}
 
 다음은 사용자의 프로필과 관심사에 맞춰 검색된 10개 채용공고입니다:
@@ -273,31 +370,45 @@ class LLMPromptingService:
 사용자 질문: {query}
 
 **중요 지침:**
-1. 사용자의 전공, 관심 직무, 수강 과목 등을 고려하여 질문 의도를 파악하세요:
-   - 채용공고 추천을 원하는 질문인가요? (예: "어떤 회사에 지원하면 좋을까요?", "추천 채용공고 알려주세요")
+1. 사용자의 질문 의도를 정확히 파악하세요:
+   - 새로운 채용공고 추천을 원하는 질문인가요? (예: "어떤 회사에 지원하면 좋을까요?", "추천 채용공고 알려주세요")
+   - 이전에 추천한 채용공고에 대한 추가 설명을 요청하는 질문인가요? (예: "첫 번째 공고에 대해 더 자세히 설명해주세요")
    - 특정 기술/직무 관련 채용공고를 찾는 질문인가요?
 
-2. **채용공고 추천이 필요한 경우:**
+2. **이전 추천 공고에 대한 설명 요청인 경우:**
+   - 대화 이력에서 해당 채용공고를 찾아 구체적으로 설명
+   - 해당 공고의 주요 내용, 요구사항, 우대사항 등을 상세히 설명
+   - 사용자 프로필과 연관지어 설명 (프로필 정보가 있는 경우)
+   - recommended_job_indices는 빈 배열로 설정 (새로운 추천이 아니므로)
+   - overall_advice에 해당 공고에 대한 구체적인 설명을 포함
+   - practical_tips에 해당 공고 지원 시 도움될 실용적인 조언 포함
+
+3. **새로운 채용공고 추천이 필요한 경우:**
    - 위 10개 채용공고 중에서 사용자의 프로필에 가장 적합한 1~3개를 선별하여 추천
    - recommended_job_indices에 해당 번호들을 포함
-   - recommendation_reasons에 사용자의 프로필 데이터를 적극 활용하여 추천 이유를 상세히 명시
-   - ⚠️ 추천 이유 작성 시 반드시 사용자의 구체적인 프로필 요소를 언급하세요:
-     * 전공과 해당 포지션의 연관성 (예: "컴퓨터공학 전공으로 이 백엔드 개발 역할에 적합")
-     * 수강 과목과 업무의 연결점 (예: "웹프로그래밍 과목 수강 경험으로 프론트엔드 업무에 바로 적용 가능")
-     * 자격증과 채용 우대 조건 (예: "정보처리기사 자격증으로 개발자 채용 시 우대")
+   - recommendation_reasons에 추천 이유를 상세히 명시
+   - 사용자의 프로필 데이터가 있다면 적극 활용:
+     * 전공과 해당 포지션의 연관성
+     * 수강 과목과 업무의 연결점
+     * 자격증과 채용 우대 조건
      * 관심 직무와 포지션의 일치도
-     * 단, 사용자의 프로필 데이터가 답변에 사용될 여지가 없다면 언급하지 않아도 됩니다.
-   - ⚠️ "채용공고 1", "채용공고 2" 같은 번호 언급 금지
-   - 각 채용공고의 추천 이유는 독립적으로 작성 (예: "이 포지션은...", "해당 회사는..." 등)
+   - "채용공고 1", "채용공고 2" 같은 번호 언급은 피하고 구체적인 회사명/직무로 언급
+   - 각 채용공고의 추천 이유는 독립적으로 작성
 
-3. **일반 상담이 섞인 경우:**
+4. **일반 상담이 필요한 경우:**
    - recommended_job_indices는 빈 배열로 설정
-   - overall_advice에 사용자 프로필을 적극 고려한 답변 제공
-   - practical_tips에 전공, 수강 과목, 자격증을 구체적으로 언급하며 맞춤형 조언 제공
-   - 예시: "컴퓨터공학 전공이시니 알고리즘 역량을 강화하세요", "웹프로그래밍 과목을 수강하셨으니 포트폴리오에 웹 프로젝트를 포함하세요"
-   - 단, 사용자의 프로필 데이터가 답변에 사용될 여지가 없다면 언급하지 않아도 됩니다.
+   - overall_advice에 질문에 대한 구체적인 답변 제공
+   - practical_tips에 실행 가능한 구체적인 조언 제공
+   - 가능한 경우 사용자 프로필 요소를 활용한 맞춤형 조언 제공
 
-사용자의 배경과 질문에 가장 도움이 되는 방식으로 응답해주세요.
+답변 시 주의사항:
+1. 항상 구체적이고 명확하게 답변하세요
+2. 실제 채용공고 내용을 기반으로 답변하세요
+3. 이전 대화 맥락을 충분히 고려하세요
+4. 불필요하게 장황한 설명은 피하고 핵심적인 내용에 집중하세요
+5. 사용자가 요청하지 않은 일반적인 조언은 최소화하세요
+
+사용자의 질문 의도에 가장 적합한 방식으로 응답해주세요.
 """
             
             # LangChain with_structured_output 방식
@@ -343,10 +454,10 @@ class LLMPromptingService:
                 },
             )
 
-            return LLMResponse(
-                content=llm_response,
-                recommended_jobs=recommended_jobs,
-            )
+            return {
+                "content": llm_response,
+                "recommended_jobs": recommended_jobs,
+            }
             
         except Exception as e:
             logger.error(f"추천 응답 생성 실패: {str(e)}")


### PR DESCRIPTION
# What is this PR? 🔍

## ➕ 이슈 링크

- issue : #100

## ➕ 개요

지금 카탈로그 데이터를 개요와 목표만 사용하고 그 와중에도 중복 단어를 모두 제거해서 손실되는 정보가 너무 많다고 생각했습니다.
또한 사용자의 인풋을 쿼리로 사용하지 않아 사용자 의도가 검색 결과에 반영되지 않는 것 같더라고요.
이런 RAG적인 조작 요소들은 추후 지표를 평가하면서 개선해나가겠지만, 당장 출력되는 응답의 품질을 위해 이정도 조작만 해놓겠습니다.

추가적으로 기존 응답은 대화 컨텍스트를 반영하고있지 않았습니다.
지금은 최근 5개의 대화를 컨텍스트로 반영하여 더 자연스러운 대화를 할 수 있도록 조정했습니다.

## ➕ 작업 내용

<!---- 변경 사항에 대해 자세하게 작성해주세요. -->


