### PR TITLE
[FEAT] 다수의 GT 프로필 생성 + 수강 이력 중복 생성 문제 해결

### DIFF
--- a/llm-service/src/api/models_gt.py
+++ b/llm-service/src/api/models_gt.py
@@ -12,3 +12,20 @@ class GeneratedGTSample(BaseModel):
     relevant_ids: List[Dict[str, Any]]  # {rec_idx, distance}
     profile: Dict[str, Any]
     query: str 
+
+
+class GTBatchGenerateRequest(BaseModel):
+    """배치 GT 생성 요청 모델"""
+    count: int = Field(100, ge=1, le=200, description="생성할 샘플 개수 (1~200)")
+    num_similar: int = Field(4, ge=1, le=5, description="각 샘플에 포함할 유사 문서 수 (1~5)")
+
+
+class GTBatchGenerateResponse(BaseModel):
+    """배치 GT 생성 응답 모델"""
+    generated: int = Field(..., description="성공적으로 생성·저장된 샘플 개수")
+    failed: int = Field(..., description="실패한 샘플 개수")
+    ids: List[int] = Field(..., description="백엔드에 저장된 GT 샘플 ID 목록 (성공 건) ")
+    errors: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description="실패한 항목의 인덱스 및 상세 오류 메시지 목록"
+    ) 

--- a/llm-service/src/api/routes_gt.py
+++ b/llm-service/src/api/routes_gt.py
@@ -9,6 +9,7 @@ from src.api.models_gt import (
 )
 from src.services.gt_agent import GTAgent
 from src.services.backend_client import BackendClient
+from src.services.gt_batch_generator import GTBatchGenerator
 
 router = APIRouter()
 
@@ -30,16 +31,12 @@ async def generate_gt(request: GTGenerateRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-# -----------------------------------------------------------------------------
-# 🆕 배치 GT 생성 엔드포인트 (Skeleton)
-# -----------------------------------------------------------------------------
-
 
 @router.post(
     "/gt/generate-batch",
     response_model=GTBatchGenerateResponse,
     summary="여러 개의 Ground Truth 샘플을 한 번에 생성",
-    description="count 개수만큼 GT 샘플을 생성하여 백엔드에 저장합니다. 현재는 스켈레톤 구현으로, 실제 생성 로직은 추후 커밋에서 추가됩니다.",
+    description="count 개수만큼 GT 샘플을 생성하여 백엔드에 저장합니다.",
 )
 async def generate_gt_batch(request: GTBatchGenerateRequest):
 
@@ -49,10 +46,12 @@ async def generate_gt_batch(request: GTBatchGenerateRequest):
         request.num_similar,
     )
 
-    # 추후 구현 예정
+    generator = GTBatchGenerator()
+    ids, errors = await generator.generate(request.count, request.num_similar)
+
     return GTBatchGenerateResponse(
-        generated=0,
-        failed=0,
-        ids=[],
-        errors=[],
+        generated=len(ids),
+        failed=len(errors),
+        ids=ids,
+        errors=errors,
     ) 

--- a/llm-service/src/api/routes_gt.py
+++ b/llm-service/src/api/routes_gt.py
@@ -1,10 +1,19 @@
 from fastapi import APIRouter, HTTPException
+import logging
+from fastapi import Body
 
-from src.api.models_gt import GTGenerateRequest
+from src.api.models_gt import (
+    GTGenerateRequest,
+    GTBatchGenerateRequest,
+    GTBatchGenerateResponse,
+)
 from src.services.gt_agent import GTAgent
 from src.services.backend_client import BackendClient
 
 router = APIRouter()
+
+# 로거 설정
+logger = logging.getLogger(__name__)
 
 
 @router.post("/gt/generate")
@@ -18,4 +27,32 @@ async def generate_gt(request: GTGenerateRequest):
 
         return {**gt_data, "id": new_id}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) 
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# -----------------------------------------------------------------------------
+# 🆕 배치 GT 생성 엔드포인트 (Skeleton)
+# -----------------------------------------------------------------------------
+
+
+@router.post(
+    "/gt/generate-batch",
+    response_model=GTBatchGenerateResponse,
+    summary="여러 개의 Ground Truth 샘플을 한 번에 생성",
+    description="count 개수만큼 GT 샘플을 생성하여 백엔드에 저장합니다. 현재는 스켈레톤 구현으로, 실제 생성 로직은 추후 커밋에서 추가됩니다.",
+)
+async def generate_gt_batch(request: GTBatchGenerateRequest):
+
+    logger.info(
+        "[generate_gt_batch] 요청 수신 | count=%s | num_similar=%s",
+        request.count,
+        request.num_similar,
+    )
+
+    # 추후 구현 예정
+    return GTBatchGenerateResponse(
+        generated=0,
+        failed=0,
+        ids=[],
+        errors=[],
+    ) 

--- a/llm-service/src/services/gt_agent.py
+++ b/llm-service/src/services/gt_agent.py
@@ -30,10 +30,14 @@ class GTAgent:
             "당신은 채용공고를 분석해 해당 공고들에 꼭 맞는 3-4학년 학생 프로필을 작성하는 전문가입니다.\n"
             "profile 필드는 JSON 형태이어야 하며 major, catalogs, interest_job, certification 키를 포함해야 합니다.\n"
             "catalogs 필드는 백엔드 search_course_catalog 응답 객체(id, course_name, course_code, credit_units, instructor, total_credits 등)를 그대로 원소로 갖는 리스트여야 합니다. 예: [{{\"id\": 2746, \"course_name\": \"AI+X:딥러닝\", \"course_code\": \"AIX0003\", \"credit_units\": \"100단위\", \"instructor\": \"원영준\", \"total_credits\": \"3.0\"}}].\n"
-            "catalogs를 채우기 위해서는 search_course_catalog 툴을 활용하세요. 키워드는 관련 과목명(예: '딥러닝', '컴퓨터비전') 또는 개설학과명(예: '컴퓨터소프트웨어학부')을 사용하여 검색할 수 있습니다. 응답 리스트 중 가장 적합한 1~3개 과목만 선택하세요.\n"
-            "catalogs의 개수는 15~20개 사이로 선택하세요.\n"
+            "catalogs를 채우기 위해서는 search_course_catalog 툴을 활용하세요. 키워드는 관련 과목명(예: '딥러닝', '컴퓨터비전') 또는 개설학과명(예: '컴퓨터소프트웨어학부')을 사용하여 검색할 수 있습니다.\n"
+            "catalogs를 채우기 위해 여러번 search_course_catalog 툴을 호출해야 할 수 있습니다. 여러 번 사용하는 동안 키워드를 다양하게 변경하여 검색하세요.(해당 프로필과 적절한 키워드로 검색하는 것이 중요합니다.)\n"
+            "search_course_catalog 툴 사용시 특정 키워드에 대해 빈 값이 반환되면 적절한 다른 키워드를 사용하여 검색하세요.\n"
+            "catalogs의 개수는 반드시 15~20개 사이로 채워야 합니다.\n"
+            "catalogs의 course_name이 중복되지 않도록 채워야 합니다.\n"
             "채용공고의 본문 내용을 참고해야겠다 생각이 들면 get_job_posting 툴을 활용하세요.\n"
             "query 필드는 학생이 챗봇에게 물어볼 하나의 질문 문장입니다.\n"
+            "학생은 챗봇에게 주로 본인 상황에 맞는 채용공고를 추천해 줄 것을 질문합니다. (예: '나는 java로 프로젝트를 몇 번 해봤고 서버 개발자가 되고 싶어. 나에게 맞는 채용 공고를 추천해줄래?', '나는 인사관리 하는 것에 관심이 있어. 나에게 맞는 채용 공고를 추천해줄래?')\n"
             "반드시 JSON 스키마 {{profile, query, relevant_ids}} 로만 응답하세요."
         )
         prompt = ChatPromptTemplate.from_messages([
@@ -42,7 +46,7 @@ class GTAgent:
             MessagesPlaceholder(variable_name="agent_scratchpad"),
         ])
         agent = create_openai_functions_agent(llm=llm, tools=tools, prompt=prompt)
-        self.executor = AgentExecutor(agent=agent, tools=tools, verbose=True, max_iterations=50)
+        self.executor = AgentExecutor(agent=agent, tools=tools, verbose=True, max_iterations=100)
 
     # -------------------- 유사 문서 검색 --------------------
     async def _all_ids(self) -> List[str]:
@@ -97,31 +101,66 @@ class GTAgent:
 
         logger.info("✅ LLM 에이전트 응답 수신 (경과 %.2f초)", time.perf_counter() - start_ts)
 
-        # ---------------- 결과 파싱 ----------------
-        if isinstance(result, dict) and "output" in result:
-            raw = result["output"]  # 에이전트 최종 응답 텍스트
-        else:
-            raw = result  # str or dict 그대로 처리
+        for attempt in range(3):
+            # ---------------- 결과 파싱 ----------------
+            if isinstance(result, dict) and "output" in result:
+                raw = result["output"]
+            else:
+                raw = result
 
-        if isinstance(raw, str):
-            try:
-                cleaned = re.sub(r"```.*?\n|```", "", raw, flags=re.S)
-                m = re.search(r"\{.*\}", cleaned, flags=re.S)
-                if m:
-                    cleaned = m.group(0)
-                cleaned2 = cleaned.replace("'", '"')
-                data = json.loads(cleaned2)
-            except Exception as e:
-                logger.error("❌ JSON 파싱 실패 | raw(앞 300자)=%s", raw[:300])
+            data = None
+            if isinstance(raw, str):
                 try:
-                    data = ast.literal_eval(cleaned)
+                    cleaned = re.sub(r"```.*?\n|```", "", raw, flags=re.S)
+                    m = re.search(r"\{.*\}", cleaned, flags=re.S)
+                    if m:
+                        cleaned = m.group(0)
+                    cleaned2 = cleaned.replace("'", '"')
+                    data = json.loads(cleaned2)
                 except Exception:
-                    logger.exception("ast.literal_eval 재시도 실패 – 결과 파싱 불가")
-                    raise e
-        elif isinstance(raw, dict):
-            data = raw
-        else:
-            raise ValueError(f"Unexpected agent output type: {type(raw)}")
+                    try:
+                        data = ast.literal_eval(cleaned)
+                    except Exception:
+                        data = None
+            elif isinstance(raw, dict):
+                data = raw
+
+            # ---------- 유효성 검사 ----------
+            valid = False
+            reason = ""
+            if data and isinstance(data, dict) and "profile" in data:
+                catalogs = data["profile"].get("catalogs", [])
+                # 중복 제거 후 개수 확인
+                seen = set()
+                dup = False
+                for c in catalogs:
+                    key = (c.get("course_code") or c.get("course_name"))
+                    if key in seen:
+                        dup = True
+                        break
+                    seen.add(key)
+                if dup:
+                    reason = "중복 과목 존재"
+                elif len(catalogs) < 15:
+                    reason = f"과목 수 부족({len(catalogs)})"
+                else:
+                    valid = True
+
+            if valid:
+                break  # validation passed
+
+            # ---------------- 피드백 메시지로 재시도 ----------------
+            feedback_msg = (
+                f"이전 출력의 문제가 있습니다: {reason}. \n"
+                "catalogs 필드는 반드시 중복 없이 15~20개 과목을 포함해야 합니다. \n"
+                "중복을 제거하고 부족하면 search_course_catalog를 추가 호출하여 채워주세요. \n"
+                "JSON 스키마 {profile, query, relevant_ids} 로만 응답하세요."
+            )
+            logger.info("🔄 재시도 %d - 이유: %s", attempt + 1, reason)
+            result = await self.executor.ainvoke({"input": feedback_msg})
+
+        if not data:
+            raise RuntimeError("GTAgent failed to produce valid JSON after retries")
 
         data["seed_rec_idx"] = seed
         data["relevant_ids"] = relevant_ids

--- a/llm-service/src/services/gt_agent.py
+++ b/llm-service/src/services/gt_agent.py
@@ -128,8 +128,8 @@ class GTAgent:
 
         logger.info("✅ LLM 에이전트 응답 수신 (경과 %.2f초)", time.perf_counter() - start_ts)
 
-        # 최대 3회 재시도
-        for attempt in range(3):
+        # 최대 5회 재시도
+        for attempt in range(5):
             # ---------------- 결과 파싱 ----------------
             if isinstance(result, dict) and "output" in result:
                 raw = result["output"]

--- a/llm-service/src/services/gt_agent.py
+++ b/llm-service/src/services/gt_agent.py
@@ -34,7 +34,7 @@ class GTAgent:
             "catalogs를 채우기 위해 여러번 search_course_catalog 툴을 호출해야 할 수 있습니다. 여러 번 사용하는 동안 키워드를 다양하게 변경하여 검색하세요.(해당 프로필과 적절한 키워드로 검색하는 것이 중요합니다.)\n"
             "search_course_catalog 툴 사용시 특정 키워드에 대해 빈 값이 반환되면 적절한 다른 키워드를 사용하여 검색하세요.\n"
             "catalogs의 개수는 반드시 15~20개 사이로 채워야 합니다.\n"
-            "catalogs의 course_name이 중복되지 않도록 채워야 합니다.\n"
+            "catalogs의 course_code 및 course_name이 중복되지 않도록 채워야 합니다. 동일한 course_code 및 course_name을 가진 과목은 절대 포함하지 마세요.\n"
             "채용공고의 본문 내용을 참고해야겠다 생각이 들면 get_job_posting 툴을 활용하세요.\n"
             "query 필드는 학생이 챗봇에게 물어볼 하나의 질문 문장입니다.\n"
             "학생은 챗봇에게 주로 본인 상황에 맞는 채용공고를 추천해 줄 것을 질문합니다. (예: '나는 java로 프로젝트를 몇 번 해봤고 서버 개발자가 되고 싶어. 나에게 맞는 채용 공고를 추천해줄래?', '나는 인사관리 하는 것에 관심이 있어. 나에게 맞는 채용 공고를 추천해줄래?')\n"
@@ -47,6 +47,31 @@ class GTAgent:
         ])
         agent = create_openai_functions_agent(llm=llm, tools=tools, prompt=prompt)
         self.executor = AgentExecutor(agent=agent, tools=tools, verbose=True, max_iterations=100)
+
+    # -------------------- 유틸리티 메서드 --------------------
+    def _deduplicate_catalogs(self, catalogs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """course_code와 course_name 기준으로 중복 제거"""
+        seen_codes = set()
+        seen_names = set()
+        unique_catalogs = []
+        
+        for catalog in catalogs:
+            course_code = catalog.get("course_code")
+            course_name = catalog.get("course_name")
+            
+            # course_code나 course_name 중 하나라도 중복이면 제외
+            if course_code in seen_codes or course_name in seen_names:
+                continue
+                
+            if course_code:
+                seen_codes.add(course_code)
+            if course_name:
+                seen_names.add(course_name)
+            unique_catalogs.append(catalog)
+            
+        return unique_catalogs
+
+
 
     # -------------------- 유사 문서 검색 --------------------
     async def _all_ids(self) -> List[str]:
@@ -82,12 +107,14 @@ class GTAgent:
 
         # Agent에게 컨텍스트 메시지 전달 (seed와 주요 후보 제목)
         context_msgs = []
+        posting_titles = []
         for obj in relevant_ids:
             rec_idx = obj["rec_idx"]
             posting = await self.ingest_client.get_posting(rec_idx)
             logger.debug("🔍 채용공고 %s 메타데이터 로드 완료", rec_idx)
             meta = posting.get("metadata", {})
             title = meta.get("post_title", meta.get("title", "제목 없음"))
+            posting_titles.append(title)
             context_msgs.append(f"- {title} (id: {rec_idx})")
         context_str = "\n".join(context_msgs)
 
@@ -101,6 +128,7 @@ class GTAgent:
 
         logger.info("✅ LLM 에이전트 응답 수신 (경과 %.2f초)", time.perf_counter() - start_ts)
 
+        # 최대 3회 재시도
         for attempt in range(3):
             # ---------------- 결과 파싱 ----------------
             if isinstance(result, dict) and "output" in result:
@@ -125,45 +153,112 @@ class GTAgent:
             elif isinstance(raw, dict):
                 data = raw
 
-            # ---------- 유효성 검사 ----------
-            valid = False
-            reason = ""
+            # ---------- 유효성 검사 및 개선된 처리 ----------
             if data and isinstance(data, dict) and "profile" in data:
                 catalogs = data["profile"].get("catalogs", [])
-                # 중복 제거 후 개수 확인
-                seen = set()
-                dup = False
-                for c in catalogs:
-                    key = (c.get("course_code") or c.get("course_name"))
-                    if key in seen:
-                        dup = True
-                        break
-                    seen.add(key)
-                if dup:
-                    reason = "중복 과목 존재"
-                elif len(catalogs) < 15:
-                    reason = f"과목 수 부족({len(catalogs)})"
+                
+                # 1. 중복 제거를 먼저 수행
+                original_count = len(catalogs)
+                catalogs = self._deduplicate_catalogs(catalogs)
+                dedup_count = len(catalogs)
+                
+                if original_count > dedup_count:
+                    logger.info("🔧 중복 과목 %d개 자동 제거 (%d → %d)", 
+                              original_count - dedup_count, original_count, dedup_count)
+                    data["profile"]["catalogs"] = catalogs
+
+                # 2. 개수 확인 및 부족분 처리
+                if dedup_count >= 15:
+                    logger.info("✅ 과목 개수 충족 (%d개)", dedup_count)
+                    break  # 성공
                 else:
-                    valid = True
+                    needed = 15 - dedup_count
+                    logger.info("📝 과목 %d개 부족 → %d개 추가 요청", dedup_count, needed)
+                    
+                    # 이미 선택된 course_code와 course_name 목록
+                    existing_codes = [c.get("course_code") for c in catalogs if c.get("course_code")]
+                    existing_names = [c.get("course_name") for c in catalogs if c.get("course_name")]
+                    
+                    feedback_msg = (
+                        f"아래 {dedup_count}개 과목은 이미 확정되었습니다:\n"
+                        f"{json.dumps(catalogs, ensure_ascii=False, indent=2)}\n\n"
+                        f"이 과목들과 course_code 또는 course_name이 중복되지 않도록 {needed}개 과목을 추가로 검색하여 채워주세요.\n"
+                        f"이미 사용된 course_code: {existing_codes}\n"
+                        f"이미 사용된 course_name: {existing_names}\n\n"
+                        f"기존 과목들과 중복되지 않도록 키워드 선정을 잘 해주세요.\n"
+                        f"추가 과목만 JSON 형태로 반환하세요: {{\"additional_catalogs\": [...]}}"
+                    )
+                    logger.info("🔄 부족분 추가 요청 (시도 %d)", attempt + 1)
+                    additional_result = await self.executor.ainvoke({"input": feedback_msg})
+                    
+                    # 추가 과목 파싱 및 병합
+                    additional_data = None
+                    if isinstance(additional_result, dict) and "output" in additional_result:
+                        additional_raw = additional_result["output"]
+                    else:
+                        additional_raw = additional_result
+                        
+                    if isinstance(additional_raw, str):
+                        try:
+                            cleaned = re.sub(r"```.*?\n|```", "", additional_raw, flags=re.S)
+                            m = re.search(r"\{.*\}", cleaned, flags=re.S)
+                            if m:
+                                cleaned = m.group(0)
+                            cleaned2 = cleaned.replace("'", '"')
+                            additional_data = json.loads(cleaned2)
+                        except Exception:
+                            try:
+                                additional_data = ast.literal_eval(cleaned)
+                            except Exception:
+                                logger.warning("⚠️ 추가 과목 파싱 실패")
+                                continue
+                    elif isinstance(additional_raw, dict):
+                        additional_data = additional_raw
+                    
+                    # 추가 과목을 기존 catalogs에 병합
+                    if additional_data and "additional_catalogs" in additional_data:
+                        additional_catalogs = additional_data["additional_catalogs"]
+                        logger.info("📚 추가 과목 %d개 수신", len(additional_catalogs))
+                        
+                        # 중복 제거하면서 병합
+                        all_catalogs = catalogs + additional_catalogs
+                        merged_catalogs = self._deduplicate_catalogs(all_catalogs)
+                        data["profile"]["catalogs"] = merged_catalogs
+                        
+                        logger.info("🔄 병합 완료: %d + %d → %d개 (중복 제거 후)", 
+                                  len(catalogs), len(additional_catalogs), len(merged_catalogs))
+                        
+                        # 병합 후 재검증
+                        if len(merged_catalogs) >= 15:
+                            break
+            else:
+                logger.warning("⚠️ 파싱 실패 또는 잘못된 구조")
+                feedback_msg = (
+                    "이전 출력이 올바른 JSON 형태가 아닙니다. "
+                    "반드시 JSON 스키마 {profile, query, relevant_ids} 로만 응답하세요."
+                )
+                logger.info("🔄 재시도 %d - JSON 형태 오류", attempt + 1)
+                result = await self.executor.ainvoke({"input": feedback_msg})
+                continue
 
-            if valid:
-                break  # validation passed
-
-            # ---------------- 피드백 메시지로 재시도 ----------------
-            feedback_msg = (
-                f"이전 출력의 문제가 있습니다: {reason}. \n"
-                "catalogs 필드는 반드시 중복 없이 15~20개 과목을 포함해야 합니다. \n"
-                "중복을 제거하고 부족하면 search_course_catalog를 추가 호출하여 채워주세요. \n"
-                "JSON 스키마 {profile, query, relevant_ids} 로만 응답하세요."
+        # 최종 검증
+        if not data or not isinstance(data, dict) or "profile" not in data:
+            raise RuntimeError(f"GTAgent failed to produce valid JSON after {3} retries")
+        
+        final_catalogs = data["profile"].get("catalogs", [])
+        final_count = len(self._deduplicate_catalogs(final_catalogs))
+        
+        if final_count < 15:
+            raise RuntimeError(
+                f"GTAgent failed to generate sufficient catalogs: {final_count}/15. "
+                f"This seed ({seed}) may not have enough relevant course data."
             )
-            logger.info("🔄 재시도 %d - 이유: %s", attempt + 1, reason)
-            result = await self.executor.ainvoke({"input": feedback_msg})
 
-        if not data:
-            raise RuntimeError("GTAgent failed to produce valid JSON after retries")
-
+        # 최종 중복 제거 적용
+        data["profile"]["catalogs"] = self._deduplicate_catalogs(final_catalogs)
         data["seed_rec_idx"] = seed
         data["relevant_ids"] = relevant_ids
 
-        logger.info("🎉 create_sample 완료 (총 %.2f초)", time.perf_counter() - start_ts)
+        logger.info("🎉 create_sample 완료 (총 %.2f초) | 최종 과목 수: %d개", 
+                   time.perf_counter() - start_ts, len(data["profile"]["catalogs"]))
         return data 

--- a/llm-service/src/services/gt_batch_generator.py
+++ b/llm-service/src/services/gt_batch_generator.py
@@ -10,12 +10,14 @@ from src.services.backend_client import BackendClient
 class GTBatchGenerator:
     """Ground Truth 샘플을 batch 로 생성·저장하는 서비스 레이어."""
 
-    DEFAULT_CONCURRENCY = 5  # 동시 작업 개수 제한
+    DEFAULT_CONCURRENCY = 2  # 동시 작업 개수 제한
+    DEFAULT_DELAY_BETWEEN_TASKS = 2.0  # 작업 간 지연 시간 (초)
 
-    def __init__(self, agent: GTAgent | None = None, concurrency: int | None = None):
+    def __init__(self, agent: GTAgent | None = None, concurrency: int | None = None, delay: float | None = None):
         self.agent = agent or GTAgent()
         self.logger = logging.getLogger(__name__)
         self.concurrency = concurrency or self.DEFAULT_CONCURRENCY
+        self.delay = delay or self.DEFAULT_DELAY_BETWEEN_TASKS
 
     async def _create_and_store_sample(self, idx: int, num_similar: int, sem: asyncio.Semaphore) -> Tuple[int | None, Dict[str, str] | None]:
         """단일 GT 샘플을 생성하고 저장한다. 성공 시 new_id 반환, 실패 시 error dict 반환."""
@@ -23,6 +25,10 @@ class GTBatchGenerator:
             try:
                 t0 = time.perf_counter()
                 self.logger.info("[%d] GT 샘플 생성 시작", idx)
+
+                # Rate limit 방지를 위한 지연
+                if idx > 1:  # 첫 번째 작업은 지연 없이 시작
+                    await asyncio.sleep(self.delay)
 
                 # 1) 샘플 생성
                 gt_data = await self.agent.create_sample(None, num_similar)

--- a/llm-service/src/services/gt_batch_generator.py
+++ b/llm-service/src/services/gt_batch_generator.py
@@ -1,0 +1,52 @@
+import logging
+from typing import List, Dict, Tuple
+
+from src.services.gt_agent import GTAgent
+from src.services.backend_client import BackendClient
+
+
+class GTBatchGenerator:
+    """Ground Truth 샘플을 batch 로 생성·저장하는 서비스 레이어."""
+
+    def __init__(self, agent: GTAgent | None = None):
+        self.agent = agent or GTAgent()
+        self.logger = logging.getLogger(__name__)
+
+    async def generate(
+        self, count: int, num_similar: int
+    ) -> Tuple[List[int], List[Dict[str, str]]]:
+        """GT 샘플을 count 개 생성하여 백엔드에 저장.
+
+        Returns
+        -------
+        ids : List[int]
+            성공적으로 저장된 샘플 ID 목록
+        errors : List[dict]
+            실패한 항목의 인덱스 및 상세 오류 메시지
+        """
+        ids: List[int] = []
+        errors: List[Dict[str, str]] = []
+
+        for idx in range(count):
+            try:
+                self.logger.info("[%d/%d] GT 샘플 생성 시작", idx + 1, count)
+
+                # 1. 샘플 생성
+                gt_data = await self.agent.create_sample(None, num_similar)
+
+                # 2. 백엔드 저장
+                async with BackendClient() as backend:
+                    new_id = await backend.create_gt_sample(gt_data)
+
+                ids.append(new_id)
+                self.logger.info(
+                    "[%d/%d] ✅ 저장 완료 | id=%s", idx + 1, count, new_id
+                )
+
+            except Exception as e:
+                self.logger.exception(
+                    "[%d/%d] ❌ 실패: %s", idx + 1, count, str(e)
+                )
+                errors.append({"idx": idx, "detail": str(e)})
+
+        return ids, errors 

--- a/llm-service/src/services/gt_batch_generator.py
+++ b/llm-service/src/services/gt_batch_generator.py
@@ -1,4 +1,6 @@
 import logging
+import asyncio
+import time
 from typing import List, Dict, Tuple
 
 from src.services.gt_agent import GTAgent
@@ -8,14 +10,47 @@ from src.services.backend_client import BackendClient
 class GTBatchGenerator:
     """Ground Truth 샘플을 batch 로 생성·저장하는 서비스 레이어."""
 
-    def __init__(self, agent: GTAgent | None = None):
+    DEFAULT_CONCURRENCY = 5  # 동시 작업 개수 제한
+
+    def __init__(self, agent: GTAgent | None = None, concurrency: int | None = None):
         self.agent = agent or GTAgent()
         self.logger = logging.getLogger(__name__)
+        self.concurrency = concurrency or self.DEFAULT_CONCURRENCY
+
+    async def _create_and_store_sample(self, idx: int, num_similar: int, sem: asyncio.Semaphore) -> Tuple[int | None, Dict[str, str] | None]:
+        """단일 GT 샘플을 생성하고 저장한다. 성공 시 new_id 반환, 실패 시 error dict 반환."""
+        async with sem:
+            try:
+                t0 = time.perf_counter()
+                self.logger.info("[%d] GT 샘플 생성 시작", idx)
+
+                # 1) 샘플 생성
+                gt_data = await self.agent.create_sample(None, num_similar)
+
+                # 2) 백엔드 저장
+                async with BackendClient() as backend:
+                    new_id = await backend.create_gt_sample(gt_data)
+
+                elapsed = time.perf_counter() - t0
+                self.logger.info("[%d] ✅ 완료 | id=%s | %.2fs", idx, new_id, elapsed)
+
+                return new_id, None
+
+            except Exception as e:
+                self.logger.exception("[%d] ❌ 실패: %s", idx, str(e))
+                return None, {"idx": idx, "detail": str(e)}
 
     async def generate(
         self, count: int, num_similar: int
     ) -> Tuple[List[int], List[Dict[str, str]]]:
-        """GT 샘플을 count 개 생성하여 백엔드에 저장.
+        """GT 샘플을 count 개 생성하여 백엔드에 저장 (병렬 처리).
+
+        Parameters
+        ----------
+        count : int
+            생성할 샘플 개수
+        num_similar : int
+            관련 문서 개수 (GTAgent 인자)
 
         Returns
         -------
@@ -24,29 +59,34 @@ class GTBatchGenerator:
         errors : List[dict]
             실패한 항목의 인덱스 및 상세 오류 메시지
         """
+
+        start_time = time.perf_counter()
+
+        sem = asyncio.Semaphore(self.concurrency)
+
+        tasks = [
+            self._create_and_store_sample(idx + 1, num_similar, sem)
+            for idx in range(count)
+        ]
+
+        results = await asyncio.gather(*tasks)
+
         ids: List[int] = []
         errors: List[Dict[str, str]] = []
-
-        for idx in range(count):
-            try:
-                self.logger.info("[%d/%d] GT 샘플 생성 시작", idx + 1, count)
-
-                # 1. 샘플 생성
-                gt_data = await self.agent.create_sample(None, num_similar)
-
-                # 2. 백엔드 저장
-                async with BackendClient() as backend:
-                    new_id = await backend.create_gt_sample(gt_data)
-
+        for new_id, err in results:
+            if new_id is not None:
                 ids.append(new_id)
-                self.logger.info(
-                    "[%d/%d] ✅ 저장 완료 | id=%s", idx + 1, count, new_id
-                )
+            if err is not None:
+                errors.append(err)
 
-            except Exception as e:
-                self.logger.exception(
-                    "[%d/%d] ❌ 실패: %s", idx + 1, count, str(e)
-                )
-                errors.append({"idx": idx, "detail": str(e)})
+        elapsed_total = time.perf_counter() - start_time
+        avg = elapsed_total / count if count else 0
+        self.logger.info(
+            "🎉 Batch GT 생성 완료 | 성공 %d | 실패 %d | 총 %.2fs | avg %.2fs",
+            len(ids),
+            len(errors),
+            elapsed_total,
+            avg,
+        )
 
         return ids, errors 

--- a/llm-service/src/services/tools.py
+++ b/llm-service/src/services/tools.py
@@ -23,7 +23,7 @@ job_posting_tool = StructuredTool.from_function(
     coroutine=_get_job_posting_async,
 )
 
-async def _search_course_async(q: str, limit: int = 1):
+async def _search_course_async(q: str, limit: int = 20):
     """백엔드 수강편람 검색 API를 호출하여 과목 정보를 반환합니다."""
     url = f"{settings.BACKEND_API_URL}/courses/search"
     async with httpx.AsyncClient(timeout=10.0) as client:
@@ -34,7 +34,7 @@ async def _search_course_async(q: str, limit: int = 1):
             return {"error": f"NO_RESULTS for keyword '{q}'"}
         return data
 
-def _search_course(q: str, limit: int = 1):
+def _search_course(q: str, limit: int = 20):
     data = asyncio.run(_search_course_async(q=q, limit=limit))
     if not data:
         return {"error": f"NO_RESULTS for keyword '{q}'"}

--- a/llm-service/src/services/tools.py
+++ b/llm-service/src/services/tools.py
@@ -29,10 +29,16 @@ async def _search_course_async(q: str, limit: int = 1):
     async with httpx.AsyncClient(timeout=10.0) as client:
         resp = await client.get(url, params={"q": q, "limit": limit})
         resp.raise_for_status()
-        return resp.json()
+        data = resp.json()
+        if not data:
+            return {"error": f"NO_RESULTS for keyword '{q}'"}
+        return data
 
 def _search_course(q: str, limit: int = 1):
-    return asyncio.run(_search_course_async(q=q, limit=limit))
+    data = asyncio.run(_search_course_async(q=q, limit=limit))
+    if not data:
+        return {"error": f"NO_RESULTS for keyword '{q}'"}
+    return data
 
 course_search_tool = StructuredTool.from_function(
     _search_course,


### PR DESCRIPTION
# What is this PR? 🔍

## ➕ 이슈 링크

- issue : #123

## ➕ 개요

에이전트로 다수의 GT 프로필 생성하는 작업입니다.

## ➕ 작업 내용

에이전트를 활용하여 다수의 GT 프로필을 뽑는 api 작업을 했습니다.
최초 100개 정도의 프로필만 생성하고 해당 프로필로 실험을 진행할 것이기 때문에 최초 한 번 실행 이후 따로 재요청 할 필요는 없습니다.
조만간 gt 생성해서 db에 남겨놓겠습니다.

에이전트가 수강편람 검색 tool을 사용하면서 자꾸 중복 수강 데이터를 채워넣는 문제가 있었는데요 (이거 해결하느라 좀 늦어졌습니다.)
에이전트가 만든 수강 이력 데이터에서 중복을 제거하고 부족한 개수만큼 다시 채우도록 에이전트를 반복해서 호출하는 방향으로 문제를 해결했습니다.

