### PR TITLE
[Feat] RAG 성능 개선을 위한 섹션별 청킹 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,35 +121,6 @@ docker swarm 기반 분산환경 구축
 <br>
 <br>
 
-## 📝 작업 순서 및 커밋 전략
-
-### 현재 진행 중인 작업
-
-전체 작업은 3개의 Phase로 나뉘어 진행됩니다:
-
-#### Phase 1: 서비스 코드를 Experiment 전략대로 변경 (우선순위: 높음) ⚡ 진행 중
-- 청킹 전략 변경 (섹션별 청킹)
-- ChromaDB 저장 방식 변경 (청크 단위)
-- 메타데이터 보존 강화
-- **현재 작업**: JobPostParser 구현 (메서드별 커밋)
-
-#### Phase 2: GT AGENT API 서비스 병합 (우선순위: 중간)
-- GT Agent 관련 API를 Backend 서비스에 통합
-- 기존 LLM Service의 GT Agent 기능을 Backend로 이동
-
-#### Phase 3: 통합 문서 및 README 정리 (우선순위: 낮음)
-- 여러 MD 파일 통합
-- README에 커밋 히스토리 반영
-- 문서 구조 정리
-
-
-### 상세 커밋 계획
-
-자세한 커밋 계획은 [`data_gt/COMMIT_STRATEGY.md`](./data_gt/COMMIT_STRATEGY.md)를 참고하세요.
-
-<br>
-<br>
-
 ## 🐹 주요 화면
 
 <img width="1822" alt="스크린샷 2025-06-09 오전 3 33 29" src="https://github.com/user-attachments/assets/d711bf56-1994-46a8-82ab-2945ae07384a" />

--- a/README.md
+++ b/README.md
@@ -121,6 +121,35 @@ docker swarm 기반 분산환경 구축
 <br>
 <br>
 
+## 📝 작업 순서 및 커밋 전략
+
+### 현재 진행 중인 작업
+
+전체 작업은 3개의 Phase로 나뉘어 진행됩니다:
+
+#### Phase 1: 서비스 코드를 Experiment 전략대로 변경 (우선순위: 높음) ⚡ 진행 중
+- 청킹 전략 변경 (섹션별 청킹)
+- ChromaDB 저장 방식 변경 (청크 단위)
+- 메타데이터 보존 강화
+- **현재 작업**: JobPostParser 구현 (메서드별 커밋)
+
+#### Phase 2: GT AGENT API 서비스 병합 (우선순위: 중간)
+- GT Agent 관련 API를 Backend 서비스에 통합
+- 기존 LLM Service의 GT Agent 기능을 Backend로 이동
+
+#### Phase 3: 통합 문서 및 README 정리 (우선순위: 낮음)
+- 여러 MD 파일 통합
+- README에 커밋 히스토리 반영
+- 문서 구조 정리
+
+
+### 상세 커밋 계획
+
+자세한 커밋 계획은 [`data_gt/COMMIT_STRATEGY.md`](./data_gt/COMMIT_STRATEGY.md)를 참고하세요.
+
+<br>
+<br>
+
 ## 🐹 주요 화면
 
 <img width="1822" alt="스크린샷 2025-06-09 오전 3 33 29" src="https://github.com/user-attachments/assets/d711bf56-1994-46a8-82ab-2945ae07384a" />

--- a/README_integration.md
+++ b/README_integration.md
@@ -1,0 +1,342 @@
+# Career-HY 🎯
+
+
+**맞춤 채용공고 추천 RAG 시스템**
+
+https://careerhy.com/
+
+<br>
+
+## 📋 프로젝트 개요
+
+Career-HY는 한양대학교 학생들의 수강 이력과 개인 프로필을 기반으로 맞춤형 채용공고를 추천하는 AI 시스템입니다. 사람인 채용공고 데이터와 수강편람 데이터를 결합하여 개인 역량에 최적화된 취업 기회를 제공합니다.
+
+<br>
+
+### 1차 개발 목표 (~ 2025년 6월 18일)
+- **초기 데이터 수집**
+   - 2025-1 수강편람 데이터 -> 검색 쿼리에 사용
+   - 2025-5월 시점 사람인 신입 채용 공고 PDF 및 메타데이터 -> 벡터 DB 임베딩에 사용
+- **MVP 선정 및 주기능 개발**
+- **초기 RAG 환경을 통해 데이터 파이프라인 구축**
+   - 초기 임베딩 모델 : OpenAI `text-embedding-ada-002`
+   - 초기 벡터 DB : Chroma DB
+   - 초기 LLM 모델 : GPT-4.0
+   - 초기 청킹 전략 : 문서 단위
+- **백엔드 - 프론트엔드 - 검색 - 출력 - 크롤링 서버 통합 연동**
+- **LangSmith 도입을 통한 LLM 애플리케이션 모니터링 및 디버깅**
+
+<br>
+
+> ⚠️ **데이터 제약사항**  
+> 현재는 2025년도 1학기 수강편람 데이터만 확보되어있는 상태입니다.  
+> 따라서 과거에 수강한 과목이 2025년 1학기 시점에 폐강된 상태라면, 해당 과목을 프로필에 추가할 수 없어 검색 쿼리로 사용하지 못합니다.
+
+<br>
+
+### 2차 개발 목표 (1차 완료 이후)
+- **RAG 파라미터 최적화 실험**
+- **답변 품질 개선을 위한 A/B 테스트**
+- **다양한 임베딩 모델 성능 비교**
+- **청킹 전략 최적화**
+- **다양한 Vector DB 및 Graph DB 성능 실험**
+- **과거 한양대학교 수강편람 데이터 추가 수집**
+- **프로덕트 관점 편의 기능 및 부가기능 개발**
+   - 채용 공고 스크랩
+   - JWT 도입
+   - 비동기 메시징 등
+- **프론트엔드 모바일 최적화**
+
+<br>
+<br>
+
+## RAG 아키텍처
+
+![RAG 아키텍처 1 1](https://github.com/user-attachments/assets/9c33450c-913e-4e7f-885c-9e1584a2bb34)
+
+
+
+<br>
+
+
+## 🏗️ 시스템 아키텍처
+
+<img width="2120" height="1360" alt="시스템아키텍처 1 1 1 1 1 2 1" src="https://github.com/user-attachments/assets/31c8bca1-6fda-40ce-900f-2d5455753261" />
+
+
+docker swarm 기반 분산환경 구축
+
+<br>
+
+## 🚀 주요 컴포넌트
+
+### 1. 📥 Ingestion
+**임베딩 처리 및 검색 서버**
+- PDF(채용 공고) 문서 로딩 및 텍스트 추출
+- 텍스트 전처리 및 정제
+- OpenAI `text-embedding-ada-002` 모델 임베딩
+- 벡터 DB 적재 및 문서 검색
+
+### 2. 🔗 Backend
+**핵심 비즈니스 로직 및 데이터 관리**
+- 사용자 관리 (회원가입, 로그인)
+- 프로필 관리 (전공, 수강 이력, 관심 분야)
+- 사용자 인풋 입력
+
+### 3. 🧠 LLM Service
+**AI 기반 상담 및 추천**
+- 요청받은 사용자 인풋 + 프로필 정보 기반 Ingestion 서버의 검색 API 호출
+- 프롬프팅
+- 사용자 맞춤형 답변 생성
+
+### 4. 🕷️ Crawler Service
+**실시간 채용정보 수집**
+- 채용 사이트 사람인 신입 채용 공고 크롤링 스케줄링
+- 수집한 데이터를 S3에 적재
+
+### 5. 📲 Frontend
+**사용자 인터페이스 및 상호작용**
+- 사용자 회원가입 및 로그인 화면
+- 개인 프로필 설정 (전공, 수강 과목, 관심 분야 등)
+- AI 상담 채팅 인터페이스
+- 채용공고 스크랩 및 관리 기능
+
+<br>
+
+## 🛠️ 기술 스택
+
+### Core Technologies
+- **벡터 DB**: ChromaDB
+- **웹 프레임워크**: FastAPI
+- **데이터베이스**: MySQL (RDS)
+- **클라우드 스토리지**: AWS S3
+- **문서 처리 및 프롬프팅**: PyMuPDF, LangChain
+- **프론트엔드**: React, Next.JS
+- **컨테이너**: Docker
+
+### 데이터 소스 ( 2025/6/3 기준 )
+- **수강편람**: 한양대학교 2025-1학기 수강편람
+- **채용공고**: 2025년 5월 기준 사람인 채용공고
+
+<br>
+<br>
+
+## 🚀 빠른 시작
+
+### 사전 준비사항
+
+1. **필수 도구 설치**
+   ```bash
+   docker --version
+   docker-compose --version
+   ```
+
+2. **환경 변수 파일 준비**
+   프로젝트 루트에 `.env` 파일을 생성하고 다음 변수들을 설정하세요:
+   ```env
+   # 데이터베이스 설정
+   DB_HOST=your_db_host
+   DB_PORT=3306
+   DB_USER=your_db_user
+   DB_PASS=your_db_password
+   DB_NAME=your_db_name
+   
+   # 애플리케이션 설정
+   SECRET_KEY=your_secret_key
+   DEBUG=true
+   CORS_ORIGINS=http://localhost:3000,http://localhost:5001
+   
+   # 세션 설정
+   SESSION_COOKIE_DOMAIN=
+   SESSION_COOKIE_SECURE=false
+   SESSION_COOKIE_SAMESITE=lax
+   
+   # 서비스 URL 설정 (Docker 네트워크 내부 통신)
+   LLM_SERVICE_URL=http://llm-service:5003
+   INGESTION_SERVICE_URL=http://ingestion:5002
+   
+   # OpenAI API 설정
+   OPENAI_API_KEY=your_openai_api_key
+   OPENAI_MODEL=gpt-4o-mini
+   ```
+
+3. **데이터베이스 준비**
+   - MySQL 데이터베이스가 실행 중이어야 합니다
+   - 데이터베이스 스키마가 생성되어 있어야 합니다
+
+### 서비스 시작
+
+```bash
+# 모든 서비스 빌드 및 시작
+docker-compose up --build
+
+# 백그라운드에서 실행
+docker-compose up -d --build
+
+# 특정 서비스만 시작
+docker-compose up backend
+```
+
+### 서비스 상태 확인
+
+```bash
+# 실행 중인 컨테이너 확인
+docker-compose ps
+
+# 서비스 로그 확인
+docker-compose logs -f backend
+docker-compose logs -f llm-service
+docker-compose logs -f ingestion
+
+# 헬스체크
+curl http://localhost:5001/health
+```
+
+### API 문서
+
+- **Swagger UI**: http://localhost:5001/docs
+- **ReDoc**: http://localhost:5001/redoc
+
+---
+
+## 🧪 API 테스트
+
+### 테스트 스크립트 사용
+
+프로젝트 루트에 제공된 테스트 스크립트를 사용할 수 있습니다:
+
+```bash
+# Bash 스크립트
+./test_api.sh
+
+# Python 스크립트
+python test_api.py
+```
+
+### 주요 API 엔드포인트
+
+#### 사용자 관리
+```bash
+# 회원가입
+curl -X POST http://localhost:5001/users/signup \
+  -H "Content-Type: application/json" \
+  -d '{"email": "test@example.com", "pwd": "password123"}'
+
+# 로그인 (세션 쿠키 저장)
+curl -X POST http://localhost:5001/users/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "test@example.com", "pwd": "password123"}' \
+  -c cookies.txt
+```
+
+#### 프로필 관리
+```bash
+# 프로필 조회 (인증 필요)
+curl -X GET http://localhost:5001/profiles -b cookies.txt
+
+# 프로필 수정
+curl -X PATCH http://localhost:5001/profiles \
+  -H "Content-Type: application/json" \
+  -b cookies.txt \
+  -d '{"major": "컴퓨터소프트웨어학부", ...}'
+```
+
+#### 채팅
+```bash
+# 채팅방 생성
+curl -X POST http://localhost:5001/chatrooms \
+  -H "Content-Type: application/json" \
+  -b cookies.txt \
+  -d '{"title": "첫 번째 채팅방"}'
+
+# LLM 응답 생성
+curl -X POST http://localhost:5003/generate-llm \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "신입 개발자 채용공고 추천해줘",
+    "profile": {...}
+  }'
+```
+
+---
+
+## 🔧 문제 해결
+
+### 서비스 간 연결 오류
+
+**증상**: `llm-service`가 `ingestion` 서비스에 연결하지 못함
+
+**해결**:
+1. `docker-compose.yml`에서 `INGESTION_SERVICE_URL=http://ingestion:5002` 설정 확인
+2. 서비스 재시작:
+   ```bash
+   docker-compose stop llm-service
+   docker-compose rm -f llm-service
+   docker-compose up -d llm-service
+   ```
+
+### 포트 충돌
+
+```bash
+# 포트 사용 중인 프로세스 확인 (macOS)
+lsof -i :5001
+
+# 포트 변경 (docker-compose.yml 수정)
+ports:
+  - "5002:5001"  # 호스트 포트를 5002로 변경
+```
+
+### 로그 확인
+
+```bash
+# 실시간 로그 확인
+docker-compose logs -f
+
+# 특정 서비스 로그만 확인
+docker-compose logs -f llm-service
+
+# 에러만 필터링
+docker-compose logs llm-service | grep -i error
+```
+
+---
+
+## 📝 작업 순서 및 커밋 전략
+
+### 현재 진행 중인 작업
+
+전체 작업은 3개의 Phase로 나뉘어 진행됩니다:
+
+#### Phase 1: 서비스 코드를 Experiment 전략대로 변경 (우선순위: 높음) ✅ 완료
+- 청킹 전략 변경 (섹션별 청킹)
+- ChromaDB 저장 방식 변경 (청크 단위)
+- 메타데이터 보존 강화
+- Docker Compose 서비스 간 통신 설정 개선
+- Pydantic v2 호환성 개선
+- 에러 핸들링 개선
+
+#### Phase 2: GT AGENT API 서비스 병합 (우선순위: 중간)
+- GT Agent 관련 API를 Backend 서비스에 통합
+- 기존 LLM Service의 GT Agent 기능을 Backend로 이동
+
+#### Phase 3: 통합 문서 및 README 정리 (우선순위: 낮음) ✅ 완료
+- 여러 MD 파일 통합
+- README에 서비스 설정 및 테스트 가이드 추가
+- 문서 구조 정리
+
+<br>
+<br>
+
+## 🐹 주요 화면
+
+<img width="1822" alt="스크린샷 2025-06-09 오전 3 33 29" src="https://github.com/user-attachments/assets/d711bf56-1994-46a8-82ab-2945ae07384a" />
+
+<img width="1822" alt="스크린샷 2025-06-09 오전 3 38 43" src="https://github.com/user-attachments/assets/37151680-47ba-4d06-9369-de6836c53dee" />
+
+
+<br>
+<br>
+
+**Developers**: 한양대학교 데이터사이언스 전공 [이의준](https://github.com/LeeEuyJoon), [최하영](https://github.com/rettooo) <br>
+**Contact**: hyuds.careerhi@gmail.com
+

--- a/crawler/requirements.txt
+++ b/crawler/requirements.txt
@@ -9,3 +9,7 @@ python-dotenv==1.0.0
 
 # HTTP 클라이언트
 requests==2.31.0
+
+# 스케줄러
+apscheduler==3.10.4
+pytz==2024.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,9 @@ services:
       - ./llm-service/logs:/app/logs
     environment:
       - VECTOR_STORE_PATH=/app/data/vector_store_pymupdf_text-embedding-ada-002_chroma
+      - INGESTION_SERVICE_URL=http://ingestion:5002
+    depends_on:
+      - ingestion
 
   crawler:
     build: ./crawler

--- a/ingestion/src/api/models.py
+++ b/ingestion/src/api/models.py
@@ -38,6 +38,8 @@ class JobPosting(BaseModel):
     crawling_time: Optional[str] = None     # 크롤링 시간
     content: str
     similarity_score: Optional[float] = None  # 유사도 점수 추가
+    section_type: Optional[str] = None      # 섹션 타입 (preferred, qualifications, job_duties 등)
+    chunk_id: Optional[str] = None          # 청크 ID
 
 
 class RetrievalRequest(BaseModel):

--- a/ingestion/src/api/routes.py
+++ b/ingestion/src/api/routes.py
@@ -73,22 +73,36 @@ async def retrieve_documents(request: RetrievalRequest) -> RetrievalResponse:
             metadatas = results["metadatas"][0]
             distances = results.get("distances", [[]])[0]
 
+            # 같은 rec_idx의 여러 청크를 그룹화 (선택사항)
+            # 현재는 각 청크를 개별적으로 반환하지만, 필요시 그룹화 로직 추가 가능
+            rec_idx_groups = {}
+            
             for idx, (doc, metadata) in enumerate(zip(documents, metadatas)):
                 # 유사도 점수 계산
                 distance = distances[idx] if idx < len(distances) else None
                 similarity = round(1.0 - distance, 4) if distance is not None else None
 
+                rec_idx = metadata.get("rec_idx")
+                
                 job_posting = JobPosting(
-                    rec_idx=metadata.get("rec_idx"),
+                    rec_idx=rec_idx,
                     title=metadata.get("post_title", "제목 없음"),
                     url=metadata.get("detail_url", ""),
                     deadline=metadata.get("deadline", "미정"),
                     start_date=metadata.get("start_date"),
                     crawling_time=metadata.get("crawling_time"),
                     content=doc,
-                    similarity_score=similarity,  # 🆕 유사도 점수 추가
+                    similarity_score=similarity,
+                    section_type=metadata.get("section_type"),  # 🆕 섹션 정보 추가
+                    chunk_id=metadata.get("chunk_id"),  # 🆕 청크 ID 추가
                 )
                 job_postings.append(job_posting)
+                
+                # 그룹화를 위한 인덱싱 (선택사항 - 향후 사용 가능)
+                if rec_idx:
+                    if rec_idx not in rec_idx_groups:
+                        rec_idx_groups[rec_idx] = []
+                    rec_idx_groups[rec_idx].append(job_posting)
 
         return RetrievalResponse(results=job_postings)
 
@@ -184,7 +198,9 @@ async def vector_search_test(request: VectorSearchRequest) -> VectorSearchRespon
                     start_date=metadata.get("start_date"),
                     crawling_time=metadata.get("crawling_time"),
                     content=doc,
-                    similarity_score=similarity,  # 🆕 유사도 점수 추가
+                    similarity_score=similarity,
+                    section_type=metadata.get("section_type"),  # 🆕 섹션 정보 추가
+                    chunk_id=metadata.get("chunk_id"),  # 🆕 청크 ID 추가
                 )
                 job_postings.append(job_posting)
 

--- a/ingestion/src/preprocessing/__init__.py
+++ b/ingestion/src/preprocessing/__init__.py
@@ -1,7 +1,9 @@
 """
 텍스트 전처리 모듈
 """
+
 from .text_loader import extract_text_PyMuPDF
 from .text_cleaner import clean_text
+from .job_post_parser import JobPostParser
 
-__all__ = ["extract_text_PyMuPDF", "clean_text"] 
+__all__ = ["extract_text_PyMuPDF", "clean_text", "JobPostParser"]

--- a/ingestion/src/preprocessing/__init__.py
+++ b/ingestion/src/preprocessing/__init__.py
@@ -5,5 +5,12 @@
 from .text_loader import extract_text_PyMuPDF
 from .text_cleaner import clean_text
 from .job_post_parser import JobPostParser
+from .structured_loader import StructuredDocumentLoader, Chunk
 
-__all__ = ["extract_text_PyMuPDF", "clean_text", "JobPostParser"]
+__all__ = [
+    "extract_text_PyMuPDF",
+    "clean_text",
+    "JobPostParser",
+    "StructuredDocumentLoader",
+    "Chunk",
+]

--- a/ingestion/src/preprocessing/job_post_parser.py
+++ b/ingestion/src/preprocessing/job_post_parser.py
@@ -8,60 +8,189 @@ unstructured 라이브러리를 사용하여 preferred, qualifications, job_duti
 from pathlib import Path
 from typing import Dict, Any, Optional
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 
 
 class JobPostParser:
     """
-    채용공고 PDF를 구조화된 섹션으로 파싱하는 클래스
-
-    Experiment 전략을 따라 섹션별 청킹을 위해 사용됩니다.
+    PDF 형태 채용공고를 주어진 전략에 따라 섹션별로 파싱합니다.
     """
 
     def __init__(self, strategy: str = "fast"):
         """
-        JobPostParser 초기화
+        JobPostParser를 초기화합니다.
 
         Args:
-            strategy: 파싱 전략 ("fast" | "hi_res")
-                - "fast": 빠른 파싱 (약 10배 빠름, 프로덕션 권장)
-                - "hi_res": 고해상도 파싱 (더 정확하지만 느림) -> 안쓰임 
+            strategy (str): 파싱 전략 ("fast" | "hi_res")
         """
-        if strategy not in ["fast", "hi_res"]:
+        if strategy not in ("fast", "hi_res"):
             raise ValueError(f"strategy must be 'fast' or 'hi_res', got '{strategy}'")
-
         self.strategy = strategy
-        logger.info(f"JobPostParser initialized with strategy: {strategy}")
-    
+
+        # 채용공고 내 주요 섹션의 탐지 키워드
+        self.section_keywords = {
+            "company_intro": [
+                "조직 소개", "팀소개", "회사 소개", "팀을 소개합니다", "회사소개", "조직소개", "Introduction", "ABOUT",
+            ],
+            "job_duties": [
+                "담당업무", "주요업무", "이런 일을 하게", "함께 할 업무에요", "모집부문", "업무내용",
+                "담당 업무", "주요 업무", "하실 일", "Responsibility", "responsibility",
+                "responsibilities", "KEY PURPOSE OF ROLE",
+            ],
+            "qualifications": [
+                "자격요건", "지원자격", "자격조건", "공통 자격요건", "이런 분을 찾고 있어요", "이런 분을 찾고",
+                "필수 사항", "필수사항", "지원 자격", "자격 요건", "필수조건", "필수 조건", "자격",
+                "requirement", "KEY RESPONSIBILITIES",
+            ],
+            "preferred": [
+                "우대사항", "이런 분이면 더 좋아요", "이런 분이면", "우대 사항", "우대조건", "우대 조건", "우대 요건", "우대요건",
+            ],
+            "benefits": [
+                "근무조건", "복리후생", "혜택 및 복지", "함께하면 받는 혜택 및 복지",
+                "이런 혜택과 복지를", "근무 조건", "복리 후생", "혜택",
+            ],
+            "hiring_process": [
+                "전형절차", "접수방법 및", "접수기간 및 방법", "제출서류", "이렇게 합류해요",
+                "전형 절차", "제출 서류", "접수 방법",
+            ],
+            "notes": [
+                "유의사항", "기타", "참고해 주세요", "채용서류 반환에 관한 고지", "유의 사항", "기타사항",
+            ],
+        }
+        logger.info(f"JobPostParser initialized with strategy: {self.strategy}")
+
     def _parse_with_unstructured(self, pdf_path: Path) -> Optional[list]:
         """
-        unstructured 라이브러리를 사용하여 PDF를 파싱합니다.
-        
+        unstructured 라이브러리를 사용해 PDF 파일을 파싱합니다.
+
         Args:
-            pdf_path: PDF 파일 경로
-            
+            pdf_path (Path): PDF 파일 경로
+
         Returns:
-            unstructured elements 리스트 또는 None (실패 시)
+            list: unstructured elements 객체 리스트 또는 None(실패시)
         """
         try:
             from unstructured.partition.pdf import partition_pdf
-            
             logger.debug(f"Parsing PDF with unstructured: {pdf_path.name}")
-            
-            # unstructured로 PDF 파싱
+
             elements = partition_pdf(
                 filename=str(pdf_path),
                 strategy=self.strategy,
-                infer_table_structure=False,  # 테이블 구조 추론 비활성화 (속도 향상)
+                infer_table_structure=False,
             )
-            
-            logger.info(f"✅ Successfully parsed PDF: {pdf_path.name} ({len(elements)} elements)")
+            logger.info(
+                f"✅ Successfully parsed PDF: {pdf_path.name} ({len(elements)} elements)"
+            )
             return elements
-            
         except ImportError:
             logger.error("❌ unstructured library not installed")
-            return None
         except Exception as e:
-            logger.error(f"❌ Failed to parse PDF with unstructured: {pdf_path.name} - {e}")
+            logger.error(
+                f"❌ Failed to parse PDF with unstructured: {pdf_path.name} - {e}"
+            )
+        return None
+
+    def _normalize_text(self, text: str) -> str:
+        """
+        텍스트의 시작 부분 특수문자 및 불필요한 문자/공백 제거 등 단순화.
+
+        Args:
+            text (str): 원본 텍스트
+        
+        Returns:
+            str: 정규화된 텍스트
+        """
+        # 줄 시작 부분 특수문자 및 괄호, 기호 제거
+        normalized = re.sub(r"^[\[\]()■◆●▶◾▪*\s]+", "", text)
+        # 앞뒤 공백/기호 추가 제거
+        normalized = normalized.strip(" *-_[]()!?")
+        return normalized
+
+    def _detect_section(self, elem) -> Optional[str]:
+        """
+        (헤더) 텍스트로부터 해당 섹션 타입 반환
+
+        Args:
+            elem: unstructured Element 객체
+
+        Returns:
+            str | None: 표준 섹션명(ex. "job_duties")
+        """
+        if not hasattr(elem, "text") or not elem.text:
             return None
+
+        normalized = self._normalize_text(elem.text)
+        for section_type, keywords in self.section_keywords.items():
+            for keyword in keywords:
+                if normalized.startswith(keyword):
+                    return section_type
+        return None
+
+    def _extract_sections(self, elements: list) -> Dict[str, str]:
+        """
+        unstructured에서 파싱된 elements에서 주요 섹션별로 텍스트를 추출.
+
+        Args:
+            elements (list): unstructured elements 리스트
+
+        Returns:
+            dict: {
+                "preferred": str,
+                "qualifications": str,
+                "job_duties": str,
+                "full_text": str
+            }
+        """
+        # 주요 섹션만 미리 빈 문자열로 세팅
+        sections = {
+            "preferred": "",
+            "qualifications": "",
+            "job_duties": "",
+            "full_text": "",
+        }
+        full_text_parts = []
+
+        current_section = None
+        current_text = []
+        for element in elements:
+            if not hasattr(element, "text") or not element.text:
+                continue
+            text = element.text.strip()
+            if not text:
+                continue
+
+            full_text_parts.append(text)
+
+            # 새 섹션 헤더 감지 (텍스트가 짧고, 키워드를 포함하면 헤더로 간주)
+            text_lower = text.lower()
+            found_header = False
+            for section_name, keywords in self.section_keywords.items():
+                for keyword in keywords:
+                    if keyword in text_lower and len(text) < 100:
+                        if current_section and current_text:
+                            sections[current_section] = "\n".join(current_text).strip()
+                        current_section = section_name
+                        current_text = []
+                        found_header = True
+                        break
+                if found_header:
+                    break
+
+            # 새 섹션이거나 기존 섹션 지속
+            if current_section:
+                current_text.append(text)
+
+        # 마지막 남은 섹션(마지막 섹션) 반영
+        if current_section and current_text:
+            sections[current_section] = "\n".join(current_text).strip()
+        
+        sections["full_text"] = "\n".join(full_text_parts).strip()
+
+        logger.debug(
+            f"Extracted sections - preferred: {len(sections['preferred'])} chars, "
+            f"qualifications: {len(sections['qualifications'])} chars, "
+            f"job_duties: {len(sections['job_duties'])} chars"
+        )
+        return sections

--- a/ingestion/src/preprocessing/job_post_parser.py
+++ b/ingestion/src/preprocessing/job_post_parser.py
@@ -6,7 +6,7 @@ unstructured 라이브러리를 사용하여 preferred, qualifications, job_duti
 """
 
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List, Tuple
 import logging
 import re
 
@@ -32,31 +32,84 @@ class JobPostParser:
         # 채용공고 내 주요 섹션의 탐지 키워드
         self.section_keywords = {
             "company_intro": [
-                "조직 소개", "팀소개", "회사 소개", "팀을 소개합니다", "회사소개", "조직소개", "Introduction", "ABOUT",
+                "조직 소개",
+                "팀소개",
+                "회사 소개",
+                "팀을 소개합니다",
+                "회사소개",
+                "조직소개",
+                "Introduction",
+                "ABOUT",
             ],
             "job_duties": [
-                "담당업무", "주요업무", "이런 일을 하게", "함께 할 업무에요", "모집부문", "업무내용",
-                "담당 업무", "주요 업무", "하실 일", "Responsibility", "responsibility",
-                "responsibilities", "KEY PURPOSE OF ROLE",
+                "담당업무",
+                "주요업무",
+                "이런 일을 하게",
+                "함께 할 업무에요",
+                "모집부문",
+                "업무내용",
+                "담당 업무",
+                "주요 업무",
+                "하실 일",
+                "Responsibility",
+                "responsibility",
+                "responsibilities",
+                "KEY PURPOSE OF ROLE",
             ],
             "qualifications": [
-                "자격요건", "지원자격", "자격조건", "공통 자격요건", "이런 분을 찾고 있어요", "이런 분을 찾고",
-                "필수 사항", "필수사항", "지원 자격", "자격 요건", "필수조건", "필수 조건", "자격",
-                "requirement", "KEY RESPONSIBILITIES",
+                "자격요건",
+                "지원자격",
+                "자격조건",
+                "공통 자격요건",
+                "이런 분을 찾고 있어요",
+                "이런 분을 찾고",
+                "필수 사항",
+                "필수사항",
+                "지원 자격",
+                "자격 요건",
+                "필수조건",
+                "필수 조건",
+                "자격",
+                "requirement",
+                "KEY RESPONSIBILITIES",
             ],
             "preferred": [
-                "우대사항", "이런 분이면 더 좋아요", "이런 분이면", "우대 사항", "우대조건", "우대 조건", "우대 요건", "우대요건",
+                "우대사항",
+                "이런 분이면 더 좋아요",
+                "이런 분이면",
+                "우대 사항",
+                "우대조건",
+                "우대 조건",
+                "우대 요건",
+                "우대요건",
             ],
             "benefits": [
-                "근무조건", "복리후생", "혜택 및 복지", "함께하면 받는 혜택 및 복지",
-                "이런 혜택과 복지를", "근무 조건", "복리 후생", "혜택",
+                "근무조건",
+                "복리후생",
+                "혜택 및 복지",
+                "함께하면 받는 혜택 및 복지",
+                "이런 혜택과 복지를",
+                "근무 조건",
+                "복리 후생",
+                "혜택",
             ],
             "hiring_process": [
-                "전형절차", "접수방법 및", "접수기간 및 방법", "제출서류", "이렇게 합류해요",
-                "전형 절차", "제출 서류", "접수 방법",
+                "전형절차",
+                "접수방법 및",
+                "접수기간 및 방법",
+                "제출서류",
+                "이렇게 합류해요",
+                "전형 절차",
+                "제출 서류",
+                "접수 방법",
             ],
             "notes": [
-                "유의사항", "기타", "참고해 주세요", "채용서류 반환에 관한 고지", "유의 사항", "기타사항",
+                "유의사항",
+                "기타",
+                "참고해 주세요",
+                "채용서류 반환에 관한 고지",
+                "유의 사항",
+                "기타사항",
             ],
         }
         logger.info(f"JobPostParser initialized with strategy: {self.strategy}")
@@ -73,6 +126,7 @@ class JobPostParser:
         """
         try:
             from unstructured.partition.pdf import partition_pdf
+
             logger.debug(f"Parsing PDF with unstructured: {pdf_path.name}")
 
             elements = partition_pdf(
@@ -98,7 +152,7 @@ class JobPostParser:
 
         Args:
             text (str): 원본 텍스트
-        
+
         Returns:
             str: 정규화된 텍스트
         """
@@ -127,6 +181,70 @@ class JobPostParser:
                 if normalized.startswith(keyword):
                     return section_type
         return None
+
+    def _group_by_sections(self, elements: List) -> Tuple[Dict[str, List], List[str]]:
+        """
+        섹션별 그룹화 및 태그 감지
+
+        각 element를 순회하며:
+        1. #태그 감지 → detected_tags에 추가
+        2. 섹션 헤더 감지 → current_section 업데이트
+        3. 현재 섹션에 element 귀속
+
+        Args:
+            elements: unstructured elements 리스트
+
+        Returns:
+            (sections, tags) 튜플
+            - sections: {section_type: [elem1, elem2, ...]}
+            - tags: ["#태그1", "#태그2", ...]
+        """
+        sections = {}
+        detected_tags = []
+        current_section = "header"  # 기본 섹션
+
+        for elem in elements:
+            if not hasattr(elem, "text") or not elem.text or not elem.text.strip():
+                continue
+
+            text = elem.text.strip()
+
+            # ========================================
+            # [태그 감지 로직]
+            # ========================================
+            if text.startswith("#"):
+                # 해당 라인의 모든 태그 추출
+                tags_in_line = re.findall(r"#\S+", text)
+                detected_tags.extend(tags_in_line)
+                continue  # 태그는 섹션에 포함하지 않음
+
+            # ========================================
+            # [섹션 감지 로직]
+            # ========================================
+            detected_section = self._detect_section(elem)
+
+            if detected_section:
+                current_section = detected_section
+                logger.debug(
+                    f"   🔖 섹션 감지: {current_section} - '{elem.text[:40]}...'"
+                )
+
+            # ========================================
+            # [섹션 귀속 로직]
+            # ========================================
+            # 키워드 미감지 시 current_section이 바뀌지 않으므로
+            # 자동으로 header 또는 직전 섹션에 귀속됨
+            if current_section not in sections:
+                sections[current_section] = []
+
+            sections[current_section].append(elem)
+
+        # 중복 태그 제거
+        unique_tags = list(set(detected_tags))
+
+        logger.debug(f"✅ {len(sections)}개 섹션 감지, {len(unique_tags)}개 태그 추출")
+
+        return sections, unique_tags
 
     def _extract_sections(self, elements: list) -> Dict[str, str]:
         """
@@ -185,7 +303,7 @@ class JobPostParser:
         # 마지막 남은 섹션(마지막 섹션) 반영
         if current_section and current_text:
             sections[current_section] = "\n".join(current_text).strip()
-        
+
         sections["full_text"] = "\n".join(full_text_parts).strip()
 
         logger.debug(

--- a/ingestion/src/preprocessing/job_post_parser.py
+++ b/ingestion/src/preprocessing/job_post_parser.py
@@ -1,0 +1,35 @@
+"""
+구조화된 채용공고 PDF 파서
+
+Experiment 전략에 따라 PDF를 섹션별로 파싱합니다.
+unstructured 라이브러리를 사용하여 preferred, qualifications, job_duties 섹션을 추출합니다.
+"""
+
+from pathlib import Path
+from typing import Dict, Any, Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class JobPostParser:
+    """
+    채용공고 PDF를 구조화된 섹션으로 파싱하는 클래스
+
+    Experiment 전략을 따라 섹션별 청킹을 위해 사용됩니다.
+    """
+
+    def __init__(self, strategy: str = "fast"):
+        """
+        JobPostParser 초기화
+
+        Args:
+            strategy: 파싱 전략 ("fast" | "hi_res")
+                - "fast": 빠른 파싱 (약 10배 빠름, 프로덕션 권장)
+                - "hi_res": 고해상도 파싱 (더 정확하지만 느림) -> 안쓰임 
+        """
+        if strategy not in ["fast", "hi_res"]:
+            raise ValueError(f"strategy must be 'fast' or 'hi_res', got '{strategy}'")
+
+        self.strategy = strategy
+        logger.info(f"JobPostParser initialized with strategy: {strategy}")

--- a/ingestion/src/preprocessing/job_post_parser.py
+++ b/ingestion/src/preprocessing/job_post_parser.py
@@ -18,16 +18,25 @@ class JobPostParser:
     PDF 형태 채용공고를 주어진 전략에 따라 섹션별로 파싱합니다.
     """
 
-    def __init__(self, strategy: str = "fast"):
+    def __init__(
+        self,
+        strategy: str = "fast",
+        include_context: bool = True,
+        min_section_length: int = 30,
+    ):
         """
         JobPostParser를 초기화합니다.
 
         Args:
             strategy (str): 파싱 전략 ("fast" | "hi_res")
+            include_context (bool): 각 청크에 회사명/직무명 컨텍스트 주입 여부
+            min_section_length (int): 최소 섹션 길이 (너무 짧은 섹션 제외)
         """
         if strategy not in ("fast", "hi_res"):
             raise ValueError(f"strategy must be 'fast' or 'hi_res', got '{strategy}'")
         self.strategy = strategy
+        self.include_context = include_context
+        self.min_section_length = min_section_length
 
         # 채용공고 내 주요 섹션의 탐지 키워드
         self.section_keywords = {
@@ -245,6 +254,73 @@ class JobPostParser:
         logger.debug(f"✅ {len(sections)}개 섹션 감지, {len(unique_tags)}개 태그 추출")
 
         return sections, unique_tags
+
+    def _sections_to_chunks(
+        self, sections: Dict[str, List], metadata: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
+        """
+        섹션을 청크로 변환
+
+        각 섹션에 대해:
+        1. 컨텍스트 주입 (회사명, 직무명)
+        2. Elements를 텍스트로 결합
+        3. 최소 길이 체크
+        4. 청크 딕셔너리 생성 (metadata 확장)
+
+        Args:
+            sections: 섹션별 elements 딕셔너리
+            metadata: 문서 메타데이터 (rec_idx, company, title, tags 포함)
+
+        Returns:
+            청크 리스트 (각 청크는 text와 metadata 포함)
+        """
+        chunks = []
+
+        # ========================================
+        # [컨텍스트 주입]
+        # ========================================
+        company = metadata.get("company", "")
+        title = metadata.get("title", "")
+
+        context = ""
+        if self.include_context and (company or title):
+            context = f"[회사: {company}] [직무: {title}]\n\n"
+
+        # 섹션별 청크 생성
+        for section_type, elements in sections.items():
+            # Elements를 텍스트로 결합
+            section_text = "\n".join(
+                [elem.text for elem in elements if elem.text and elem.text.strip()]
+            )
+
+            # 최소 길이 체크
+            if len(section_text.strip()) < self.min_section_length:
+                logger.debug(
+                    f"   ⚠️ 섹션 '{section_type}' 너무 짧음 ({len(section_text)}자), 스킵"
+                )
+                continue
+
+            # 컨텍스트 주입
+            final_text = context + section_text if context else section_text
+
+            # ========================================
+            # [청크 딕셔너리 생성]
+            # ========================================
+            chunk = {
+                "text": final_text,
+                "metadata": {
+                    **metadata,  # rec_idx, company, title, tags 포함
+                    "section_type": section_type,
+                    "section_length": len(section_text),
+                    "chunk_method": "structured_parsing",
+                    "has_context": self.include_context,
+                },
+            }
+
+            chunks.append(chunk)
+            logger.debug(f"   ✅ Chunk 생성: {section_type} ({len(section_text)}자)")
+
+        return chunks
 
     def _extract_sections(self, elements: list) -> Dict[str, str]:
         """

--- a/ingestion/src/preprocessing/job_post_parser.py
+++ b/ingestion/src/preprocessing/job_post_parser.py
@@ -123,6 +123,86 @@ class JobPostParser:
         }
         logger.info(f"JobPostParser initialized with strategy: {self.strategy}")
 
+    def process_document(
+        self, doc_path: str, original_metadata: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
+        """
+        메인 오케스트레이터: 문서 파싱 → 섹션 그룹화 → 청크 생성
+
+        Args:
+            doc_path: 문서 파일 경로 (PDF, DOCX 등)
+            original_metadata: 원본 메타데이터
+                - rec_idx (필수): 문서 고유 식별자
+                - company (필수): 회사명
+                - title (필수): 직무명
+
+        Returns:
+            청크 리스트 (각 청크는 text와 metadata 포함)
+        """
+        # 필수 필드 검증 (rec_idx 또는 rec_id 허용, 하위 호환성)
+        rec_idx = original_metadata.get("rec_idx") or original_metadata.get("rec_id")
+        if not rec_idx:
+            raise ValueError("original_metadata must contain 'rec_idx' or 'rec_id'")
+
+        required_fields = ["company", "title"]
+        for field in required_fields:
+            if field not in original_metadata:
+                raise ValueError(f"original_metadata must contain '{field}'")
+
+        # rec_idx가 없으면 rec_id를 rec_idx로 설정 (하위 호환성)
+        if "rec_idx" not in original_metadata and "rec_id" in original_metadata:
+            original_metadata["rec_idx"] = original_metadata["rec_id"]
+
+        logger.info(f"\n{'='*70}")
+        logger.info(f"📄 문서 처리: {original_metadata.get('rec_idx')}")
+        logger.info(f"   회사: {original_metadata.get('company')}")
+        logger.info(f"   직무: {original_metadata.get('title')}")
+        logger.info(f"{'='*70}")
+
+        # Step 1: 문서 파싱
+        doc_path_obj = Path(doc_path)
+        elements = self._parse_document(doc_path_obj)
+        if not elements:
+            logger.warning(f"⚠️ 문서 파싱 실패: {doc_path}")
+            return []
+
+        logger.info(f"✅ {len(elements)}개 elements 추출")
+
+        # Step 2: 섹션 그룹화 및 태그 감지
+        sections, tags = self._group_by_sections(elements)
+        logger.info(f"✅ {len(sections)}개 섹션 감지")
+        logger.info(f"✅ {len(tags)}개 태그 추출: {tags[:5]}...")  # 처음 5개만
+
+        # Step 3: 메타데이터 업데이트
+        doc_metadata = original_metadata.copy()
+        doc_metadata["tags"] = tags
+
+        # Step 4: 청크 생성 (후처리)
+        chunks = self._sections_to_chunks(sections, doc_metadata)
+        logger.info(f"✅ {len(chunks)}개 청크 생성")
+
+        return chunks
+
+    def _parse_document(self, doc_path: Path) -> Optional[List]:
+        """
+        문서 파싱: unstructured로 문서 로드
+
+        Args:
+            doc_path: 문서 파일 경로
+
+        Returns:
+            elements 리스트 또는 None
+        """
+        logger.debug(f"📥 문서 로드 중... (strategy: {self.strategy})")
+
+        # PDF 파일인지 확인
+        if doc_path.suffix.lower() == ".pdf":
+            return self._parse_with_unstructured(doc_path)
+        else:
+            # 기타 파일 형식 (TXT 등) - 현재는 PDF만 지원
+            logger.warning(f"⚠️ 지원하지 않는 파일 형식: {doc_path.suffix}")
+            return None
+
     def _parse_with_unstructured(self, pdf_path: Path) -> Optional[list]:
         """
         unstructured 라이브러리를 사용해 PDF 파일을 파싱합니다.

--- a/ingestion/src/preprocessing/job_post_parser.py
+++ b/ingestion/src/preprocessing/job_post_parser.py
@@ -33,3 +33,35 @@ class JobPostParser:
 
         self.strategy = strategy
         logger.info(f"JobPostParser initialized with strategy: {strategy}")
+    
+    def _parse_with_unstructured(self, pdf_path: Path) -> Optional[list]:
+        """
+        unstructured 라이브러리를 사용하여 PDF를 파싱합니다.
+        
+        Args:
+            pdf_path: PDF 파일 경로
+            
+        Returns:
+            unstructured elements 리스트 또는 None (실패 시)
+        """
+        try:
+            from unstructured.partition.pdf import partition_pdf
+            
+            logger.debug(f"Parsing PDF with unstructured: {pdf_path.name}")
+            
+            # unstructured로 PDF 파싱
+            elements = partition_pdf(
+                filename=str(pdf_path),
+                strategy=self.strategy,
+                infer_table_structure=False,  # 테이블 구조 추론 비활성화 (속도 향상)
+            )
+            
+            logger.info(f"✅ Successfully parsed PDF: {pdf_path.name} ({len(elements)} elements)")
+            return elements
+            
+        except ImportError:
+            logger.error("❌ unstructured library not installed")
+            return None
+        except Exception as e:
+            logger.error(f"❌ Failed to parse PDF with unstructured: {pdf_path.name} - {e}")
+            return None

--- a/ingestion/src/preprocessing/structured_loader.py
+++ b/ingestion/src/preprocessing/structured_loader.py
@@ -289,6 +289,22 @@ class StructuredDocumentLoader:
                 chunks.append(Chunk(text=chunk_text, metadata=chunk_metadata))
             return chunks
 
+    def get_section_chunks(self, section_type: str) -> List[Chunk]:
+        """
+        특정 섹션 타입의 청크만 필터링
+
+        Args:
+            section_type: "preferred", "qualifications", "job_duties"
+
+        Returns:
+            필터링된 청크 리스트
+        """
+        return [
+            chunk
+            for chunk in self.chunks
+            if chunk.metadata.get("section_type") == section_type
+        ]
+
     def load_from_documents(
         self, documents: List[Dict[str, Any]], limit: Optional[int] = None
     ) -> List[Chunk]:

--- a/ingestion/src/preprocessing/structured_loader.py
+++ b/ingestion/src/preprocessing/structured_loader.py
@@ -16,34 +16,16 @@ logger = logging.getLogger(__name__)
 
 class Chunk:
     """
-    청크 데이터 클래스
-    text + metadata로 구성
-    metadata는 ChromaDB 저장용으로 설계됨
-
-    원본 메타데이터 필드 보존:
-    - deadline, start_date, crawling_time 등 원본 S3 JSON 메타데이터 전체 포함
+    청크 데이터 클래스 (text + metadata)
+    - metadata: ChromaDB 저장용(PGVector/ChromaDB 등)으로 사용
+    - 원본 S3 JSON의 전체 필드(deadline, start_date, crawling_time 등 포함)는
+      청크별 메타데이터 생성 시(_create_chunks_from_parsed)에서 합쳐서 넣어줌
+    - 여기서는 실제로 해당 딕셔너리 전체가 들어와도 primitive 타입(str/int/float/bool/None)만 보존
     """
 
     def __init__(self, text: str, metadata: Dict[str, Any]):
-        """
-        Args:
-            text: 청크 텍스트 (섹션 내용)
-            metadata: ChromaDB 저장용 메타데이터
-                - chunk_id (str): 고유 ID
-                - rec_idx (str): 문서 ID
-                - company (str): 회사명
-                - title (str): 직무명
-                - url (str): 상세 URL
-                - section_type (str): 섹션 타입
-                - section_length (int): 섹션 길이
-                - tags (list): 태그 리스트
-                - deadline (str): 마감일 (원본 메타데이터)
-                - start_date (str): 모집 시작일 (원본 메타데이터)
-                - crawling_time (str): 크롤링 시간 (원본 메타데이터)
-                - 기타 원본 메타데이터 필드 전체 포함
-        """
         self.text = text
-        # 원본 메타데이터 전체 보존 (primitive 타입만)
+        # primitive 타입 메타데이터 필드만 따로 추림 (embedding DB schema 호환)
         self.metadata = {
             key: value
             for key, value in metadata.items()
@@ -51,7 +33,7 @@ class Chunk:
         }
 
     def to_dict(self) -> Dict[str, Any]:
-        """딕셔너리 변환"""
+        """dict로 변환 (embedding 저장용)"""
         return {"text": self.text, "metadata": self.metadata}
 
     def __repr__(self):
@@ -60,16 +42,13 @@ class Chunk:
 
 class StructuredDocumentLoader:
     """
-    JobPostParser를 활용한 구조화 문서 로더
+    JobPostParser 기반 구조화 문서 로더
 
-    특징:
-    - 섹션별 청크 생성 (preferred, qualifications, job_duties)
-    - ChromaDB 호환 메타데이터 자동 생성
-    - 태그는 문서 레벨에서 추출 (모든 청크에 공유)
-    - benefits, hiring_process, notes는 제외
+    - 섹션별 청크 생성(preferred/qualification/job_duties)
+    - ChromaDB용 메타데이터 생성 구조에서 S3 원본 JSON 전체 dict까지 metadata에 포함시킴
+    - Chunk는 primitive 타입만 보존하니 크기 부담 없이 활용 가능
     """
 
-    # 임베딩 대상 섹션 (나머지는 제외)
     DEFAULT_TARGET_SECTIONS = ["preferred", "qualifications", "job_duties"]
 
     def __init__(
@@ -78,13 +57,6 @@ class StructuredDocumentLoader:
         target_sections: Optional[List[str]] = None,
         include_context: bool = True,
     ):
-        """
-        Args:
-            strategy: unstructured 파싱 전략 ("fast", "hi_res")
-            target_sections: 로드할 섹션 타입 리스트
-                None이면 DEFAULT_TARGET_SECTIONS 사용
-            include_context: JobPostParser의 context 주입 여부
-        """
         self.parser = JobPostParser(strategy=strategy, include_context=include_context)
         self.target_sections = target_sections or self.DEFAULT_TARGET_SECTIONS
         self.chunks: List[Chunk] = []
@@ -97,32 +69,20 @@ class StructuredDocumentLoader:
     @staticmethod
     def extract_company_and_title(text: str) -> tuple:
         """
-        캐시된 텍스트에서 회사명과 직무명 추출
-
-        패턴:
-        - 회사명: "관심기업" 키워드 바로 앞 줄
-        - 직무명: "관심기업" 키워드 바로 뒤 줄
-
-        Args:
-            text: 문서 전체 텍스트
-
-        Returns:
-            (company, title) 튜플
+        문서텍스트에서 회사명/직무명 추출 (간단 룰 기반: 관심기업 패턴/없는 경우 앞 2줄)
         """
         lines = text.split("\n")
         company = "미상"
         title = "미상"
 
         try:
-            # 회사명 추출: "관심기업" 전까지의 첫 번째 의미있는 줄
             for i, line in enumerate(lines):
                 line = line.strip()
                 if not line or "---" in line or "Page" in line:
                     continue
 
-                # "관심기업" 키워드를 찾으면 그 전 줄이 회사명
                 if "관심기업" in line:
-                    # 이전 줄들 중 의미있는 줄 찾기
+                    # 위쪽으로 회사명 추출
                     for j in range(i - 1, -1, -1):
                         prev_line = lines[j].strip()
                         if (
@@ -132,16 +92,13 @@ class StructuredDocumentLoader:
                         ):
                             company = prev_line
                             break
-
-                    # 직무명: "관심기업" 다음 의미있는 줄
+                    # 아래쪽으로 직무 타이틀 추출
                     for j in range(i + 1, min(i + 5, len(lines))):
                         next_line = lines[j].strip()
-                        if next_line and len(next_line) > 5:  # 충분히 긴 줄
+                        if next_line and len(next_line) > 5:
                             title = next_line
                             break
                     break
-
-            # "관심기업" 키워드가 없는 경우, 처음 나오는 의미있는 2개 줄
             if company == "미상":
                 meaningful_lines = []
                 for line in lines:
@@ -155,13 +112,76 @@ class StructuredDocumentLoader:
                         meaningful_lines.append(line)
                         if len(meaningful_lines) >= 2:
                             break
-
                 if len(meaningful_lines) >= 1:
                     company = meaningful_lines[0]
                 if len(meaningful_lines) >= 2:
                     title = meaningful_lines[1]
-
         except Exception as e:
             logger.warning(f"    ⚠️ 회사/직무 추출 실패: {e}")
 
         return company, title
+
+    def _create_chunks_from_parsed(
+        self,
+        parsed_chunks: List[Dict[str, Any]],
+        base_metadata: Dict[str, Any],
+        raw_text: str = "",
+    ) -> List[Chunk]:
+        """
+        JobPostParser 결과를 Chunk 객체로 변환.
+        - S3 메타데이터(원본 전체 dict)는 base_metadata로 합쳐서 embedding에 쓸 수 있게 chunk_metadata에 미리 통합
+        - 각 chunk 생성시 Chunk()로 전달 (init에서 primitive만 추려 유지)
+        """
+        doc_tags = []
+        if parsed_chunks:
+            doc_tags = parsed_chunks[0].get("metadata", {}).get("tags", [])
+        chunks = []
+        from collections import defaultdict
+        section_counters = defaultdict(int)
+
+        for parsed_chunk in parsed_chunks:
+            section_type = parsed_chunk.get("metadata", {}).get(
+                "section_type", "unknown"
+            )
+            if section_type not in self.target_sections:
+                continue
+            text = parsed_chunk.get("text", "")
+            if not text or len(text.strip()) < 10:
+                continue
+
+            chunk_idx = section_counters[section_type]
+            section_counters[section_type] += 1
+            chunk_id = f"{base_metadata['rec_idx']}_{section_type}_{chunk_idx}"
+
+            chunk_metadata = {
+                **base_metadata,
+                "chunk_id": chunk_id,
+                "rec_idx": base_metadata["rec_idx"],
+                "company": base_metadata.get("company") or base_metadata.get("company_name"),
+                "title": base_metadata.get("title") or base_metadata.get("post_title"),
+                "url": base_metadata.get("url") or base_metadata.get("detail_url"),
+                "section_type": section_type,
+                "section_length": len(text),
+                "tags": doc_tags,
+                "deadline": base_metadata.get("deadline"),
+                "start_date": base_metadata.get("start_date"),
+                "crawling_time": base_metadata.get("crawling_time"),
+            }
+            chunks.append(Chunk(text=text, metadata=chunk_metadata))
+
+        if not chunks and raw_text:
+            fallback_chunks = self._create_fallback_chunk(
+                raw_text=raw_text, base_metadata=base_metadata, tags=doc_tags
+            )
+            chunks.extend(fallback_chunks)
+
+            if len(fallback_chunks) == 1 and fallback_chunks[0].metadata.get(
+                "is_lightweight"
+            ):
+                logger.info(f"   💡 경량 컨텍스트 생성: {base_metadata['rec_idx']}")
+            else:
+                logger.info(
+                    f"   ✂️  Fallback 청킹 ({len(fallback_chunks)}개): {base_metadata['rec_idx']}"
+                )
+
+        return chunks

--- a/ingestion/src/preprocessing/structured_loader.py
+++ b/ingestion/src/preprocessing/structured_loader.py
@@ -27,9 +27,8 @@ class Chunk:
         self.text = text
         # primitive 타입 메타데이터 필드만 따로 추림 (embedding DB schema 호환)
         self.metadata = {
-            key: value
-            for key, value in metadata.items()
-            if isinstance(value, (str, int, float, bool, type(None)))
+            k: v for k, v in metadata.items()
+            if isinstance(v, (str, int, float, bool, type(None)))
         }
 
     def to_dict(self) -> Dict[str, Any]:
@@ -85,11 +84,7 @@ class StructuredDocumentLoader:
                     # 위쪽으로 회사명 추출
                     for j in range(i - 1, -1, -1):
                         prev_line = lines[j].strip()
-                        if (
-                            prev_line
-                            and "---" not in prev_line
-                            and "Page" not in prev_line
-                        ):
+                        if prev_line and "---" not in prev_line and "Page" not in prev_line:
                             company = prev_line
                             break
                     # 아래쪽으로 직무 타이틀 추출
@@ -100,26 +95,90 @@ class StructuredDocumentLoader:
                             break
                     break
             if company == "미상":
-                meaningful_lines = []
-                for line in lines:
-                    line = line.strip()
-                    if (
-                        line
-                        and "---" not in line
-                        and "Page" not in line
-                        and len(line) > 2
-                    ):
-                        meaningful_lines.append(line)
-                        if len(meaningful_lines) >= 2:
-                            break
-                if len(meaningful_lines) >= 1:
+                meaningful_lines = [
+                    line.strip() for line in lines
+                    if line.strip() and "---" not in line and "Page" not in line and len(line.strip()) > 2
+                ]
+                if meaningful_lines:
                     company = meaningful_lines[0]
-                if len(meaningful_lines) >= 2:
+                if len(meaningful_lines) > 1:
                     title = meaningful_lines[1]
         except Exception as e:
             logger.warning(f"    ⚠️ 회사/직무 추출 실패: {e}")
 
         return company, title
+
+    def _get_base_metadata(self, doc_metadata, raw_text, idx=0):
+        # raw_text에서 회사명과 직무명 추출 (메타데이터에 없을 때만)
+        company, title = self.extract_company_and_title(raw_text)
+        rec_id = doc_metadata.get("rec_idx", f"unknown_{idx}")
+
+        base_metadata = {
+            **doc_metadata,
+            "rec_idx": str(rec_id),
+            "title": (
+                doc_metadata.get("title")
+                or doc_metadata.get("post_title")
+                or title
+            ),
+            "company": (
+                doc_metadata.get("company")
+                or doc_metadata.get("company_name")
+                or company
+            ),
+            "url": (
+                doc_metadata.get("url")
+                or doc_metadata.get(
+                    "detail_url",
+                    f"https://www.saramin.co.kr/zf_user/jobs/relay/view?view_type=public-recruit&rec_idx={rec_id}",
+                )
+            ),
+            # 원본 필드명도 명시적으로 보존 (하위 호환성)
+            "post_title": (
+                doc_metadata.get("post_title")
+                or doc_metadata.get("title")
+                or title
+            ),
+            "company_name": (
+                doc_metadata.get("company_name")
+                or doc_metadata.get("company")
+                or company
+            ),
+            "detail_url": (
+                doc_metadata.get("detail_url")
+                or doc_metadata.get("url")
+                or ""
+            ),
+        }
+
+        # S3 JSON 메타데이터 필드명 매핑 (필요한 경우)
+        for key in ["deadline", "start_date", "crawling_time"]:
+            if key not in base_metadata or base_metadata.get(key) is None:
+                base_metadata[key] = doc_metadata.get(key)
+
+        return base_metadata
+
+    def _chunk_common_metadata(self, base_metadata, section_type, text, doc_tags, chunk_id, extra=None):
+        """
+        중복되는 chunk metadata 생성 로직 공통화
+        """
+        metadata = {
+            **base_metadata,
+            "chunk_id": chunk_id,
+            "rec_idx": base_metadata["rec_idx"],
+            "company": base_metadata.get("company") or base_metadata.get("company_name"),
+            "title": base_metadata.get("title") or base_metadata.get("post_title"),
+            "url": base_metadata.get("url") or base_metadata.get("detail_url"),
+            "section_type": section_type,
+            "section_length": len(text),
+            "tags": doc_tags,
+            "deadline": base_metadata.get("deadline"),
+            "start_date": base_metadata.get("start_date"),
+            "crawling_time": base_metadata.get("crawling_time"),
+        }
+        if extra:
+            metadata.update(extra)
+        return metadata
 
     def _create_chunks_from_parsed(
         self,
@@ -132,43 +191,25 @@ class StructuredDocumentLoader:
         - S3 메타데이터(원본 전체 dict)는 base_metadata로 합쳐서 embedding에 쓸 수 있게 chunk_metadata에 미리 통합
         - 각 chunk 생성시 Chunk()로 전달 (init에서 primitive만 추려 유지)
         """
-        doc_tags = []
-        if parsed_chunks:
-            doc_tags = parsed_chunks[0].get("metadata", {}).get("tags", [])
-        chunks = []
+        doc_tags = parsed_chunks[0].get("metadata", {}).get("tags", []) if parsed_chunks else []
         from collections import defaultdict
-
         section_counters = defaultdict(int)
+        chunks = []
 
         for parsed_chunk in parsed_chunks:
-            section_type = parsed_chunk.get("metadata", {}).get(
-                "section_type", "unknown"
-            )
+            section_type = parsed_chunk.get("metadata", {}).get("section_type", "unknown")
             if section_type not in self.target_sections:
                 continue
             text = parsed_chunk.get("text", "")
             if not text or len(text.strip()) < 10:
                 continue
-
             chunk_idx = section_counters[section_type]
             section_counters[section_type] += 1
             chunk_id = f"{base_metadata['rec_idx']}_{section_type}_{chunk_idx}"
 
-            chunk_metadata = {
-                **base_metadata,
-                "chunk_id": chunk_id,
-                "rec_idx": base_metadata["rec_idx"],
-                "company": base_metadata.get("company")
-                or base_metadata.get("company_name"),
-                "title": base_metadata.get("title") or base_metadata.get("post_title"),
-                "url": base_metadata.get("url") or base_metadata.get("detail_url"),
-                "section_type": section_type,
-                "section_length": len(text),
-                "tags": doc_tags,
-                "deadline": base_metadata.get("deadline"),
-                "start_date": base_metadata.get("start_date"),
-                "crawling_time": base_metadata.get("crawling_time"),
-            }
+            chunk_metadata = self._chunk_common_metadata(
+                base_metadata, section_type, text, doc_tags, chunk_id
+            )
             chunks.append(Chunk(text=text, metadata=chunk_metadata))
 
         if not chunks and raw_text:
@@ -176,15 +217,10 @@ class StructuredDocumentLoader:
                 raw_text=raw_text, base_metadata=base_metadata, tags=doc_tags
             )
             chunks.extend(fallback_chunks)
-
-            if len(fallback_chunks) == 1 and fallback_chunks[0].metadata.get(
-                "is_lightweight"
-            ):
+            if len(fallback_chunks) == 1 and fallback_chunks[0].metadata.get("is_lightweight"):
                 logger.info(f"   💡 경량 컨텍스트 생성: {base_metadata['rec_idx']}")
             else:
-                logger.info(
-                    f"   ✂️  Fallback 청킹 ({len(fallback_chunks)}개): {base_metadata['rec_idx']}"
-                )
+                logger.info(f"   ✂️  Fallback 청킹 ({len(fallback_chunks)}개): {base_metadata['rec_idx']}")
 
         return chunks
 
@@ -197,17 +233,7 @@ class StructuredDocumentLoader:
         하이브리드 접근:
         - 900자 이하: 경량 컨텍스트 (회사+직무+태그만)
         - 900자 초과: 400자 단위 청킹
-
-        Args:
-            raw_text: 문서 원본 텍스트
-            base_metadata: 기본 메타데이터 (rec_idx, company, title, url 포함)
-                원본 S3 JSON 메타데이터 전체 포함 (deadline, start_date, crawling_time 등)
-            tags: 문서 태그
-
-        Returns:
-            Fallback Chunk 객체 리스트
         """
-        # 전처리된 텍스트 길이 확인
         max_raw_length = 2000
         truncated_raw_text = raw_text[:max_raw_length]
 
@@ -217,38 +243,28 @@ class StructuredDocumentLoader:
             f"[직무: {base_metadata['title']}]\n\n"
             f"{truncated_raw_text}"
         )
-
         text_length = len(full_text_with_context)
 
         # 900자 이하: 경량 컨텍스트 생성
         if text_length <= 900:
-            lightweight_text = f"회사: {base_metadata['company']}\n"
-            lightweight_text += f"직무: {base_metadata['title']}\n"
-
+            lightweight_lines = [
+                f"회사: {base_metadata['company']}",
+                f"직무: {base_metadata['title']}"
+            ]
             if tags:
                 tags_str = ", ".join(tags[:5])
                 if len(tags) > 5:
                     tags_str += f" 외 {len(tags)-5}개"
-                lightweight_text += f"태그: {tags_str}"
+                lightweight_lines.append(f"태그: {tags_str}")
 
-            chunk_metadata = {
-                **base_metadata,  # 원본 S3 JSON 메타데이터 전체 포함
-                "chunk_id": f"{base_metadata['rec_idx']}_full_text_0",
-                "rec_idx": base_metadata["rec_idx"],
-                "company": base_metadata.get("company")
-                or base_metadata.get("company_name"),
-                "title": base_metadata.get("title") or base_metadata.get("post_title"),
-                "url": base_metadata.get("url") or base_metadata.get("detail_url"),
-                "section_type": "full_text",
-                "section_length": len(lightweight_text),
-                "tags": tags,
-                "is_fallback": True,
-                "is_lightweight": True,
-                # deadline, start_date, crawling_time 명시적으로 보장
-                "deadline": base_metadata.get("deadline"),
-                "start_date": base_metadata.get("start_date"),
-                "crawling_time": base_metadata.get("crawling_time"),
-            }
+            lightweight_text = "\n".join(lightweight_lines)
+            chunk_id = f"{base_metadata['rec_idx']}_full_text_0"
+            chunk_metadata = self._chunk_common_metadata(
+                base_metadata, "full_text", lightweight_text, tags, chunk_id, extra={
+                    "is_fallback": True,
+                    "is_lightweight": True,
+                }
+            )
 
             return [Chunk(text=lightweight_text, metadata=chunk_metadata)]
 
@@ -256,34 +272,111 @@ class StructuredDocumentLoader:
         else:
             chunks = []
             chunk_size = 400
-            num_chunks = (text_length + chunk_size - 1) // chunk_size  # 올림
+            num_chunks = (text_length + chunk_size - 1) // chunk_size
 
             for i in range(num_chunks):
                 start_idx = i * chunk_size
                 end_idx = min(start_idx + chunk_size, text_length)
                 chunk_text = full_text_with_context[start_idx:end_idx]
-
-                chunk_metadata = {
-                    **base_metadata,  # 원본 S3 JSON 메타데이터 전체 포함
-                    "chunk_id": f"{base_metadata['rec_idx']}_full_text_{i}",
-                    "rec_idx": base_metadata["rec_idx"],
-                    "company": base_metadata.get("company")
-                    or base_metadata.get("company_name"),
-                    "title": base_metadata.get("title")
-                    or base_metadata.get("post_title"),
-                    "url": base_metadata.get("url") or base_metadata.get("detail_url"),
-                    "section_type": "full_text",
-                    "section_length": len(chunk_text),
-                    "tags": tags,
-                    "is_fallback": True,
-                    "chunk_index": i,
-                    "total_chunks": num_chunks,
-                    # deadline, start_date, crawling_time 명시적으로 보장
-                    "deadline": base_metadata.get("deadline"),
-                    "start_date": base_metadata.get("start_date"),
-                    "crawling_time": base_metadata.get("crawling_time"),
-                }
-
+                chunk_id = f"{base_metadata['rec_idx']}_full_text_{i}"
+                chunk_metadata = self._chunk_common_metadata(
+                    base_metadata, "full_text", chunk_text, tags, chunk_id, extra={
+                        "is_fallback": True,
+                        "chunk_index": i,
+                        "total_chunks": num_chunks,
+                    }
+                )
                 chunks.append(Chunk(text=chunk_text, metadata=chunk_metadata))
-
             return chunks
+
+    def load_from_documents(
+        self, documents: List[Dict[str, Any]], limit: Optional[int] = None
+    ) -> List[Chunk]:
+        """
+        메모리에 이미 로드된 documents 리스트에서 바로 파싱 및 청크 생성
+
+        Args:
+            documents: S3DataLoader.load_documents() 형태의 리스트 (각 원소: {"text": str, "metadata": dict})
+            limit: 처리할 문서 수 제한 (None이면 전체)
+        """
+        logger.info(f"\n{'='*80}")
+        logger.info(f"📂 메모리 문서 리스트에서 구조화 파싱 시작 (JobPostParser + unstructured)")
+        logger.info(f"{'='*80}")
+
+        total_docs = len(documents)
+        process_count = limit if limit else total_docs
+
+        logger.info(f"✅ 총 문서: {total_docs}개")
+        logger.info(f"🎯 처리 대상: {process_count}개")
+        logger.info(f"\n{'='*80}")
+        logger.info(f"📋 문서 파싱 시작 (in-memory)")
+        logger.info(f"{'='*80}\n")
+
+        self.chunks = []
+        failed_docs = []
+        docs_to_process = documents[:process_count]
+
+        for idx, doc_item in enumerate(docs_to_process):
+            try:
+                doc_metadata = doc_item.get("metadata", {})
+                raw_text = doc_item.get("text", "")
+                rec_id = doc_metadata.get("rec_idx", f"unknown_{idx}")
+
+                # base_metadata 생성 (중복 제거)
+                base_metadata = self._get_base_metadata(doc_metadata, raw_text, idx)
+
+                if idx == 0:
+                    # 첫번째 문서의 메타데이터 확인
+                    logger.info(f"\n🔍 첫 번째 문서 메타데이터 확인 (rec_idx: {rec_id}):")
+                    for key in ["deadline", "start_date", "crawling_time", "post_title", "company_name"]:
+                        logger.info(f"   - {key}: {doc_metadata.get(key)}")
+                    logger.info(f"   - 전체 메타데이터 키: {list(doc_metadata.keys())[:20]}")
+
+                # 텍스트 검증
+                if not raw_text or len(raw_text) < 50:
+                    failed_docs.append((rec_id, "텍스트 없음"))
+                    continue
+
+                # 임시 파일로 저장하여 JobPostParser 사용 (unstructured 기반)
+                with tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".txt", delete=False, encoding="utf-8"
+                ) as tmp_file:
+                    tmp_file.write(raw_text)
+                    tmp_path = tmp_file.name
+
+                parsed_chunks = self.parser.process_document(
+                    doc_path=tmp_path, original_metadata=base_metadata
+                )
+                Path(tmp_path).unlink()
+
+                doc_chunks = self._create_chunks_from_parsed(
+                    parsed_chunks, base_metadata=base_metadata, raw_text=raw_text
+                )
+                self.chunks.extend(doc_chunks)
+
+            except Exception as e:
+                error_msg = str(e)
+                import traceback
+
+                if idx < 3:  # 처음 3개만 상세 에러 출력
+                    logger.error(f"\n❌ 문서 {idx} 파싱 실패 (rec_idx: {rec_id}):")
+                    logger.error(f"   에러: {error_msg}")
+                    logger.error(f"   상세:")
+                    traceback.print_exc()
+                failed_docs.append((rec_id, error_msg))
+                continue
+
+        logger.info(f"\n{'='*80}")
+        logger.info(f"✅ in-memory 파싱 완료")
+        logger.info(f"{'='*80}")
+        logger.info(f"📊 총 청크 수: {len(self.chunks)}개")
+        logger.info(f"❌ 실패 문서: {len(failed_docs)}개")
+
+        if failed_docs:
+            logger.info(f"\n실패 문서 목록 (최대 20개):")
+            for rec_id, reason in failed_docs[:20]:
+                logger.info(f"  - {rec_id}: {reason}")
+            if len(failed_docs) > 20:
+                logger.info(f"  ... 외 {len(failed_docs) - 20}개 실패")
+
+        return self.chunks

--- a/ingestion/src/preprocessing/structured_loader.py
+++ b/ingestion/src/preprocessing/structured_loader.py
@@ -137,6 +137,7 @@ class StructuredDocumentLoader:
             doc_tags = parsed_chunks[0].get("metadata", {}).get("tags", [])
         chunks = []
         from collections import defaultdict
+
         section_counters = defaultdict(int)
 
         for parsed_chunk in parsed_chunks:
@@ -157,7 +158,8 @@ class StructuredDocumentLoader:
                 **base_metadata,
                 "chunk_id": chunk_id,
                 "rec_idx": base_metadata["rec_idx"],
-                "company": base_metadata.get("company") or base_metadata.get("company_name"),
+                "company": base_metadata.get("company")
+                or base_metadata.get("company_name"),
                 "title": base_metadata.get("title") or base_metadata.get("post_title"),
                 "url": base_metadata.get("url") or base_metadata.get("detail_url"),
                 "section_type": section_type,
@@ -185,3 +187,103 @@ class StructuredDocumentLoader:
                 )
 
         return chunks
+
+    def _create_fallback_chunk(
+        self, raw_text: str, base_metadata: Dict[str, Any], tags: List[str]
+    ) -> List[Chunk]:
+        """
+        Target 섹션이 없을 때 fallback 청크 생성
+
+        하이브리드 접근:
+        - 900자 이하: 경량 컨텍스트 (회사+직무+태그만)
+        - 900자 초과: 400자 단위 청킹
+
+        Args:
+            raw_text: 문서 원본 텍스트
+            base_metadata: 기본 메타데이터 (rec_idx, company, title, url 포함)
+                원본 S3 JSON 메타데이터 전체 포함 (deadline, start_date, crawling_time 등)
+            tags: 문서 태그
+
+        Returns:
+            Fallback Chunk 객체 리스트
+        """
+        # 전처리된 텍스트 길이 확인
+        max_raw_length = 2000
+        truncated_raw_text = raw_text[:max_raw_length]
+
+        # Context 추가한 전체 텍스트
+        full_text_with_context = (
+            f"[회사: {base_metadata['company']}] "
+            f"[직무: {base_metadata['title']}]\n\n"
+            f"{truncated_raw_text}"
+        )
+
+        text_length = len(full_text_with_context)
+
+        # 900자 이하: 경량 컨텍스트 생성
+        if text_length <= 900:
+            lightweight_text = f"회사: {base_metadata['company']}\n"
+            lightweight_text += f"직무: {base_metadata['title']}\n"
+
+            if tags:
+                tags_str = ", ".join(tags[:5])
+                if len(tags) > 5:
+                    tags_str += f" 외 {len(tags)-5}개"
+                lightweight_text += f"태그: {tags_str}"
+
+            chunk_metadata = {
+                **base_metadata,  # 원본 S3 JSON 메타데이터 전체 포함
+                "chunk_id": f"{base_metadata['rec_idx']}_full_text_0",
+                "rec_idx": base_metadata["rec_idx"],
+                "company": base_metadata.get("company")
+                or base_metadata.get("company_name"),
+                "title": base_metadata.get("title") or base_metadata.get("post_title"),
+                "url": base_metadata.get("url") or base_metadata.get("detail_url"),
+                "section_type": "full_text",
+                "section_length": len(lightweight_text),
+                "tags": tags,
+                "is_fallback": True,
+                "is_lightweight": True,
+                # deadline, start_date, crawling_time 명시적으로 보장
+                "deadline": base_metadata.get("deadline"),
+                "start_date": base_metadata.get("start_date"),
+                "crawling_time": base_metadata.get("crawling_time"),
+            }
+
+            return [Chunk(text=lightweight_text, metadata=chunk_metadata)]
+
+        # 900자 초과: 400자 단위 청킹
+        else:
+            chunks = []
+            chunk_size = 400
+            num_chunks = (text_length + chunk_size - 1) // chunk_size  # 올림
+
+            for i in range(num_chunks):
+                start_idx = i * chunk_size
+                end_idx = min(start_idx + chunk_size, text_length)
+                chunk_text = full_text_with_context[start_idx:end_idx]
+
+                chunk_metadata = {
+                    **base_metadata,  # 원본 S3 JSON 메타데이터 전체 포함
+                    "chunk_id": f"{base_metadata['rec_idx']}_full_text_{i}",
+                    "rec_idx": base_metadata["rec_idx"],
+                    "company": base_metadata.get("company")
+                    or base_metadata.get("company_name"),
+                    "title": base_metadata.get("title")
+                    or base_metadata.get("post_title"),
+                    "url": base_metadata.get("url") or base_metadata.get("detail_url"),
+                    "section_type": "full_text",
+                    "section_length": len(chunk_text),
+                    "tags": tags,
+                    "is_fallback": True,
+                    "chunk_index": i,
+                    "total_chunks": num_chunks,
+                    # deadline, start_date, crawling_time 명시적으로 보장
+                    "deadline": base_metadata.get("deadline"),
+                    "start_date": base_metadata.get("start_date"),
+                    "crawling_time": base_metadata.get("crawling_time"),
+                }
+
+                chunks.append(Chunk(text=chunk_text, metadata=chunk_metadata))
+
+            return chunks

--- a/ingestion/src/preprocessing/structured_loader.py
+++ b/ingestion/src/preprocessing/structured_loader.py
@@ -93,3 +93,75 @@ class StructuredDocumentLoader:
         logger.info(f"   - 파싱 전략: {strategy}")
         logger.info(f"   - 대상 섹션: {', '.join(self.target_sections)}")
         logger.info(f"   - Context 주입: {include_context}")
+
+    @staticmethod
+    def extract_company_and_title(text: str) -> tuple:
+        """
+        캐시된 텍스트에서 회사명과 직무명 추출
+
+        패턴:
+        - 회사명: "관심기업" 키워드 바로 앞 줄
+        - 직무명: "관심기업" 키워드 바로 뒤 줄
+
+        Args:
+            text: 문서 전체 텍스트
+
+        Returns:
+            (company, title) 튜플
+        """
+        lines = text.split("\n")
+        company = "미상"
+        title = "미상"
+
+        try:
+            # 회사명 추출: "관심기업" 전까지의 첫 번째 의미있는 줄
+            for i, line in enumerate(lines):
+                line = line.strip()
+                if not line or "---" in line or "Page" in line:
+                    continue
+
+                # "관심기업" 키워드를 찾으면 그 전 줄이 회사명
+                if "관심기업" in line:
+                    # 이전 줄들 중 의미있는 줄 찾기
+                    for j in range(i - 1, -1, -1):
+                        prev_line = lines[j].strip()
+                        if (
+                            prev_line
+                            and "---" not in prev_line
+                            and "Page" not in prev_line
+                        ):
+                            company = prev_line
+                            break
+
+                    # 직무명: "관심기업" 다음 의미있는 줄
+                    for j in range(i + 1, min(i + 5, len(lines))):
+                        next_line = lines[j].strip()
+                        if next_line and len(next_line) > 5:  # 충분히 긴 줄
+                            title = next_line
+                            break
+                    break
+
+            # "관심기업" 키워드가 없는 경우, 처음 나오는 의미있는 2개 줄
+            if company == "미상":
+                meaningful_lines = []
+                for line in lines:
+                    line = line.strip()
+                    if (
+                        line
+                        and "---" not in line
+                        and "Page" not in line
+                        and len(line) > 2
+                    ):
+                        meaningful_lines.append(line)
+                        if len(meaningful_lines) >= 2:
+                            break
+
+                if len(meaningful_lines) >= 1:
+                    company = meaningful_lines[0]
+                if len(meaningful_lines) >= 2:
+                    title = meaningful_lines[1]
+
+        except Exception as e:
+            logger.warning(f"    ⚠️ 회사/직무 추출 실패: {e}")
+
+        return company, title

--- a/ingestion/src/preprocessing/structured_loader.py
+++ b/ingestion/src/preprocessing/structured_loader.py
@@ -1,0 +1,95 @@
+"""
+StructuredDocumentLoader: JobPostParser 기반 구조화 문서 로더
+
+섹션별 청크 생성 및 ChromaDB 메타데이터 관리
+"""
+
+from pathlib import Path
+from typing import List, Dict, Any, Optional
+import logging
+import tempfile
+
+from .job_post_parser import JobPostParser
+
+logger = logging.getLogger(__name__)
+
+
+class Chunk:
+    """
+    청크 데이터 클래스
+    text + metadata로 구성
+    metadata는 ChromaDB 저장용으로 설계됨
+
+    원본 메타데이터 필드 보존:
+    - deadline, start_date, crawling_time 등 원본 S3 JSON 메타데이터 전체 포함
+    """
+
+    def __init__(self, text: str, metadata: Dict[str, Any]):
+        """
+        Args:
+            text: 청크 텍스트 (섹션 내용)
+            metadata: ChromaDB 저장용 메타데이터
+                - chunk_id (str): 고유 ID
+                - rec_idx (str): 문서 ID
+                - company (str): 회사명
+                - title (str): 직무명
+                - url (str): 상세 URL
+                - section_type (str): 섹션 타입
+                - section_length (int): 섹션 길이
+                - tags (list): 태그 리스트
+                - deadline (str): 마감일 (원본 메타데이터)
+                - start_date (str): 모집 시작일 (원본 메타데이터)
+                - crawling_time (str): 크롤링 시간 (원본 메타데이터)
+                - 기타 원본 메타데이터 필드 전체 포함
+        """
+        self.text = text
+        # 원본 메타데이터 전체 보존 (primitive 타입만)
+        self.metadata = {
+            key: value
+            for key, value in metadata.items()
+            if isinstance(value, (str, int, float, bool, type(None)))
+        }
+
+    def to_dict(self) -> Dict[str, Any]:
+        """딕셔너리 변환"""
+        return {"text": self.text, "metadata": self.metadata}
+
+    def __repr__(self):
+        return f"Chunk(chunk_id={self.metadata.get('chunk_id')}, section={self.metadata.get('section_type')}, length={len(self.text)})"
+
+
+class StructuredDocumentLoader:
+    """
+    JobPostParser를 활용한 구조화 문서 로더
+
+    특징:
+    - 섹션별 청크 생성 (preferred, qualifications, job_duties)
+    - ChromaDB 호환 메타데이터 자동 생성
+    - 태그는 문서 레벨에서 추출 (모든 청크에 공유)
+    - benefits, hiring_process, notes는 제외
+    """
+
+    # 임베딩 대상 섹션 (나머지는 제외)
+    DEFAULT_TARGET_SECTIONS = ["preferred", "qualifications", "job_duties"]
+
+    def __init__(
+        self,
+        strategy: str = "fast",
+        target_sections: Optional[List[str]] = None,
+        include_context: bool = True,
+    ):
+        """
+        Args:
+            strategy: unstructured 파싱 전략 ("fast", "hi_res")
+            target_sections: 로드할 섹션 타입 리스트
+                None이면 DEFAULT_TARGET_SECTIONS 사용
+            include_context: JobPostParser의 context 주입 여부
+        """
+        self.parser = JobPostParser(strategy=strategy, include_context=include_context)
+        self.target_sections = target_sections or self.DEFAULT_TARGET_SECTIONS
+        self.chunks: List[Chunk] = []
+
+        logger.info(f"✅ StructuredDocumentLoader 초기화")
+        logger.info(f"   - 파싱 전략: {strategy}")
+        logger.info(f"   - 대상 섹션: {', '.join(self.target_sections)}")
+        logger.info(f"   - Context 주입: {include_context}")

--- a/ingestion/src/services/data_processor.py
+++ b/ingestion/src/services/data_processor.py
@@ -879,9 +879,38 @@ class DataProcessor:
             
             # 3. 청크별 임베딩 생성
             logger.info(f"🔮 {len(chunks)}개 청크의 임베딩 생성 중...")
-            chunk_texts = [chunk.text for chunk in chunks]
-            chunk_metadatas = [chunk.metadata for chunk in chunks]
-            chunk_ids = [chunk.metadata.get("chunk_id", f"chunk_{i}") for i, chunk in enumerate(chunks)]
+            chunk_texts = []
+            chunk_metadatas = []
+            chunk_ids = []
+            
+            for chunk in chunks:
+                chunk_texts.append(chunk.text)
+                
+                # 청크 메타데이터 가져오기
+                metadata = chunk.metadata.copy()
+                
+                # 청크 ID 생성: {rec_idx}_{chunk_id} 형식 보장
+                rec_idx = metadata.get("rec_idx", "unknown")
+                chunk_id = metadata.get("chunk_id")
+                
+                if not chunk_id:
+                    # fallback: rec_idx가 없으면 인덱스 기반 생성
+                    chunk_id = f"{rec_idx}_chunk_{len(chunk_ids)}"
+                elif not chunk_id.startswith(rec_idx):
+                    # chunk_id에 rec_idx가 포함되지 않은 경우 추가
+                    chunk_id = f"{rec_idx}_{chunk_id}"
+                
+                # 메타데이터에 청크 ID 업데이트
+                metadata["chunk_id"] = chunk_id
+                
+                # 섹션 정보 메타데이터 확인 및 보강
+                if "section_type" not in metadata:
+                    metadata["section_type"] = "unknown"
+                if "section_length" not in metadata:
+                    metadata["section_length"] = len(chunk.text)
+                
+                chunk_metadatas.append(metadata)
+                chunk_ids.append(chunk_id)
             
             batch_size = 50
             all_embeddings = []

--- a/ingestion/src/services/data_processor.py
+++ b/ingestion/src/services/data_processor.py
@@ -371,9 +371,38 @@ class DataProcessor:
             
             # 3. 청크별 임베딩 생성 및 저장
             logger.info(f"🔮 {len(chunks)}개 청크의 임베딩 생성 중...")
-            chunk_texts = [chunk.text for chunk in chunks]
-            chunk_metadatas = [chunk.metadata for chunk in chunks]
-            chunk_ids = [chunk.metadata.get("chunk_id", f"chunk_{i}") for i, chunk in enumerate(chunks)]
+            chunk_texts = []
+            chunk_metadatas = []
+            chunk_ids = []
+            
+            for chunk in chunks:
+                chunk_texts.append(chunk.text)
+                
+                # 청크 메타데이터 가져오기
+                metadata = chunk.metadata.copy()
+                
+                # 청크 ID 생성: {rec_idx}_{chunk_id} 형식 보장
+                rec_idx = metadata.get("rec_idx", "unknown")
+                chunk_id = metadata.get("chunk_id")
+                
+                if not chunk_id:
+                    # fallback: rec_idx가 없으면 인덱스 기반 생성
+                    chunk_id = f"{rec_idx}_chunk_{len(chunk_ids)}"
+                elif not chunk_id.startswith(rec_idx):
+                    # chunk_id에 rec_idx가 포함되지 않은 경우 추가
+                    chunk_id = f"{rec_idx}_{chunk_id}"
+                
+                # 메타데이터에 청크 ID 업데이트
+                metadata["chunk_id"] = chunk_id
+                
+                # 섹션 정보 메타데이터 확인 및 보강
+                if "section_type" not in metadata:
+                    metadata["section_type"] = "unknown"
+                if "section_length" not in metadata:
+                    metadata["section_length"] = len(chunk.text)
+                
+                chunk_metadatas.append(metadata)
+                chunk_ids.append(chunk_id)
             
             # 임베딩 생성 (배치 처리)
             batch_size = 50

--- a/ingestion/src/services/data_processor.py
+++ b/ingestion/src/services/data_processor.py
@@ -586,11 +586,37 @@ class DataProcessor:
 
             logger.info(f"📋 {len(json_dict)}개의 JSON 레코드 인덱싱 완료")
 
-            # 4. PDF 텍스트 추출 및 JSON 메타데이터 매칭
-            logger.info("🔍 PDF 텍스트 추출 및 메타데이터 매칭 중...")
-            pdf_documents = []
-            pdf_metadatas = []
-            pdf_ids = []
+            # 4. StructuredDocumentLoader 사용 여부에 따라 처리 방식 분기
+            if self.use_structured_loader and self.structured_loader:
+                # Experiment 전략: StructuredDocumentLoader 사용
+                return self._process_incremental_data_with_structured_loader(
+                    pdf_paths, json_dict, force_update, temp_dir
+                )
+            else:
+                # 기존 방식: PyMuPDF 사용
+                return self._process_incremental_data_legacy(
+                    pdf_paths, json_dict, force_update
+                )
+
+    def _process_incremental_data_legacy(
+        self, pdf_paths: List[Path], json_dict: Dict[str, Any], force_update: bool
+    ) -> Dict[str, Any]:
+        """
+        기존 방식: PyMuPDF를 사용한 증분 업데이트
+        
+        Args:
+            pdf_paths: PDF 파일 경로 리스트
+            json_dict: JSON 메타데이터 딕셔너리
+            force_update: 중복 시 덮어쓰기 여부
+            
+        Returns:
+            처리 결과 요약
+        """
+        # PDF 텍스트 추출 및 JSON 메타데이터 매칭
+        logger.info("🔍 PDF 텍스트 추출 및 메타데이터 매칭 중... (기존 방식)")
+        pdf_documents = []
+        pdf_metadatas = []
+        pdf_ids = []
 
             for pdf_path in pdf_paths:
                 try:
@@ -713,8 +739,150 @@ class DataProcessor:
                     "skipped": 0,
                 }
 
+    def _process_incremental_data_with_structured_loader(
+        self,
+        pdf_paths: List[Path],
+        json_dict: Dict[str, Any],
+        force_update: bool,
+        temp_dir: Path,
+    ) -> Dict[str, Any]:
+        """
+        Experiment 전략: StructuredDocumentLoader를 사용한 증분 업데이트
+        
+        Args:
+            pdf_paths: PDF 파일 경로 리스트
+            json_dict: JSON 메타데이터 딕셔너리
+            force_update: 중복 시 덮어쓰기 여부
+            temp_dir: 임시 디렉토리 경로
+            
+        Returns:
+            처리 결과 요약
+        """
+        try:
+            logger.info("🔍 StructuredDocumentLoader를 사용한 증분 업데이트 시작...")
+            
+            # 1. 문서 리스트 생성
+            documents = []
+            
+            for pdf_path in pdf_paths:
+                try:
+                    raw_text = extract_text_PyMuPDF(pdf_path)
+                    clean_text_result = clean_text(raw_text)
+                    
+                    if not clean_text_result.strip():
+                        continue
+                    
+                    pdf_filename = pdf_path.stem
+                    rec_idx = (
+                        pdf_filename.split("_")[-1]
+                        if "_" in pdf_filename
+                        else pdf_filename
+                    )
+                    
+                    json_metadata = json_dict.get(rec_idx, {})
+                    
+                    doc_item = {
+                        "text": clean_text_result,
+                        "metadata": {
+                            "source": "pdf",
+                            "filename": pdf_path.name,
+                            "document_type": "recruitment_pdf_with_json" if json_metadata else "recruitment_pdf_only",
+                            "rec_idx": rec_idx,
+                            **json_metadata,
+                        }
+                    }
+                    
+                    documents.append(doc_item)
+                    
+                except Exception as e:
+                    logger.error(f"❌ PDF 처리 실패 {pdf_path.name}: {e}")
+                    continue
+            
+            if not documents:
+                logger.warning("⚠️ 처리할 문서가 없습니다.")
+                return {
+                    "success": False,
+                    "error": "No documents to process",
+                    "added": 0,
+                    "updated": 0,
+                    "skipped": 0,
+                }
+            
+            # 2. StructuredDocumentLoader로 청크 생성
+            logger.info(f"📦 {len(documents)}개 문서에서 청크 생성 중...")
+            chunks = self.structured_loader.load_from_documents(documents)
+            
+            if not chunks:
+                logger.warning("⚠️ 생성된 청크가 없습니다.")
+                return {
+                    "success": False,
+                    "error": "No chunks generated",
+                    "added": 0,
+                    "updated": 0,
+                    "skipped": 0,
+                }
+            
+            # 3. 청크별 임베딩 생성
+            logger.info(f"🔮 {len(chunks)}개 청크의 임베딩 생성 중...")
+            chunk_texts = [chunk.text for chunk in chunks]
+            chunk_metadatas = [chunk.metadata for chunk in chunks]
+            chunk_ids = [chunk.metadata.get("chunk_id", f"chunk_{i}") for i, chunk in enumerate(chunks)]
+            
+            batch_size = 50
+            all_embeddings = []
+            
+            for i in range(0, len(chunk_texts), batch_size):
+                batch_texts = chunk_texts[i : i + batch_size]
+                batch_num = (i // batch_size) + 1
+                total_batches = (len(chunk_texts) + batch_size - 1) // batch_size
+                
+                logger.info(f"📊 임베딩 배치 {batch_num}/{total_batches} 처리 중... ({len(batch_texts)}개 청크)")
+                
+                try:
+                    batch_embeddings = self.embedder.embed(batch_texts)
+                    all_embeddings.extend(batch_embeddings)
+                    logger.info(f"✅ 임베딩 배치 {batch_num}/{total_batches} 완료")
+                except Exception as e:
+                    logger.error(f"❌ 임베딩 배치 {batch_num} 처리 실패: {e}")
+                    continue
+            
+            if len(all_embeddings) != len(chunk_texts):
+                logger.warning(f"⚠️ 임베딩 개수 불일치: 청크 {len(chunk_texts)}개, 임베딩 {len(all_embeddings)}개")
+                valid_count = len(all_embeddings)
+                chunk_texts = chunk_texts[:valid_count]
+                chunk_metadatas = chunk_metadatas[:valid_count]
+                chunk_ids = chunk_ids[:valid_count]
+            
+            # 4. ChromaDB에 청크 단위 Upsert
+            logger.info(f"💾 {len(chunk_texts)}개 청크를 ChromaDB에 Upsert 중... (force_update={force_update})")
+            upsert_result = upsert_to_chroma(
+                texts=chunk_texts,
+                embeddings=all_embeddings,
+                ids=chunk_ids,
+                metadatas=chunk_metadatas,
+                persist_dir=self.persist_dir,
+                force_update=force_update,
+            )
+            
+            result = {
+                "success": True,
+                "pdf_files_processed": len(pdf_paths),
+                "json_records_processed": len(json_dict),
+                "total_documents": len(documents),
+                "total_chunks": len(chunk_texts),
+                "added": upsert_result["added"],
+                "updated": upsert_result["updated"],
+                "skipped": upsert_result["skipped"],
+                "chunks_per_document_avg": len(chunk_texts) / len(documents) if documents else 0,
+            }
+            
+            logger.info(f"🎉 증분 데이터 처리 완료: {result}")
+            return result
+            
         except Exception as e:
-            logger.error(f"❌ 증분 데이터 처리 중 오류 발생: {e}")
+            logger.error(f"❌ StructuredDocumentLoader 증분 처리 중 오류 발생: {e}")
+            import traceback
+            traceback.print_exc()
             return {
                 "success": False,
                 "error": str(e),
@@ -722,11 +890,6 @@ class DataProcessor:
                 "updated": 0,
                 "skipped": 0,
             }
-
-        finally:
-            # 임시 파일 정리
-            if pdf_paths:
-                self.s3_loader.cleanup_temp_files(pdf_paths)
 
     def find_s3_files_by_rec_idx(self, rec_idx: str) -> Dict[str, str]:
         """

--- a/ingestion/src/services/data_processor.py
+++ b/ingestion/src/services/data_processor.py
@@ -74,10 +74,33 @@ class DataProcessor:
 
             logger.info(f"📋 {len(json_dict)}개의 JSON 레코드 인덱싱 완료")
 
-            # 4. PDF 텍스트 추출 및 JSON 메타데이터 매칭
-            logger.info("🔍 PDF 텍스트 추출 및 JSON 메타데이터 매칭 중...")
-            pdf_documents = []
-            pdf_metadatas = []
+            # 4. StructuredDocumentLoader 사용 여부에 따라 처리 방식 분기
+            if self.use_structured_loader and self.structured_loader:
+                # Experiment 전략: StructuredDocumentLoader 사용
+                return self._process_s3_data_with_structured_loader(
+                    pdf_paths, json_dict
+                )
+            else:
+                # 기존 방식: PyMuPDF 사용
+                return self._process_s3_data_legacy(pdf_paths, json_dict)
+
+    def _process_s3_data_legacy(
+        self, pdf_paths: List[Path], json_dict: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        기존 방식: PyMuPDF를 사용한 전체 문서 단위 처리
+        
+        Args:
+            pdf_paths: PDF 파일 경로 리스트
+            json_dict: JSON 메타데이터 딕셔너리
+            
+        Returns:
+            처리 결과 요약
+        """
+        # 4. PDF 텍스트 추출 및 JSON 메타데이터 매칭
+        logger.info("🔍 PDF 텍스트 추출 및 JSON 메타데이터 매칭 중... (기존 방식)")
+        pdf_documents = []
+        pdf_metadatas = []
 
             for pdf_path in pdf_paths:
                 try:
@@ -250,10 +273,173 @@ class DataProcessor:
                 "total_documents_stored": 0,
             }
 
-        finally:
-            # 임시 파일 정리
-            if pdf_paths:
-                self.s3_loader.cleanup_temp_files(pdf_paths)
+    def _process_s3_data_with_structured_loader(
+        self, pdf_paths: List[Path], json_dict: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Experiment 전략: StructuredDocumentLoader를 사용한 청크 단위 처리
+        
+        Args:
+            pdf_paths: PDF 파일 경로 리스트
+            json_dict: JSON 메타데이터 딕셔너리
+            
+        Returns:
+            처리 결과 요약
+        """
+        try:
+            logger.info("🔍 StructuredDocumentLoader를 사용한 청크 단위 처리 시작...")
+            
+            # 1. 문서 리스트 생성 (StructuredDocumentLoader 형식)
+            documents = []
+            
+            for pdf_path in pdf_paths:
+                try:
+                    # PDF 텍스트 추출
+                    raw_text = extract_text_PyMuPDF(pdf_path)
+                    clean_text_result = clean_text(raw_text)
+                    
+                    if not clean_text_result.strip():
+                        continue
+                    
+                    # PDF 파일명에서 rec_idx 추출
+                    pdf_filename = pdf_path.stem
+                    if "_" in pdf_filename:
+                        rec_idx = pdf_filename.split("_")[-1]
+                    else:
+                        rec_idx = pdf_filename
+                    
+                    # JSON 메타데이터 찾기
+                    json_metadata = json_dict.get(rec_idx, {})
+                    
+                    # StructuredDocumentLoader 형식으로 문서 생성
+                    doc_item = {
+                        "text": clean_text_result,
+                        "metadata": {
+                            "source": "pdf",
+                            "filename": pdf_path.name,
+                            "document_type": "recruitment_pdf_with_json" if json_metadata else "recruitment_pdf_only",
+                            "rec_idx": rec_idx,
+                            **json_metadata,  # 원본 JSON 메타데이터 전체 포함
+                        }
+                    }
+                    
+                    documents.append(doc_item)
+                    logger.debug(f"✅ 문서 추가: {rec_idx}")
+                    
+                except Exception as e:
+                    logger.error(f"❌ PDF 처리 실패 {pdf_path.name}: {e}")
+                    continue
+            
+            if not documents:
+                logger.warning("⚠️ 처리할 문서가 없습니다.")
+                return {
+                    "success": False,
+                    "error": "No documents to process",
+                    "pdf_files_processed": len(pdf_paths),
+                    "json_records_processed": len(json_dict),
+                    "total_chunks_stored": 0,
+                }
+            
+            # 2. StructuredDocumentLoader로 청크 생성
+            logger.info(f"📦 {len(documents)}개 문서에서 청크 생성 중...")
+            chunks = self.structured_loader.load_from_documents(documents)
+            
+            if not chunks:
+                logger.warning("⚠️ 생성된 청크가 없습니다.")
+                return {
+                    "success": False,
+                    "error": "No chunks generated",
+                    "pdf_files_processed": len(pdf_paths),
+                    "json_records_processed": len(json_dict),
+                    "total_chunks_stored": 0,
+                }
+            
+            # 3. 청크별 임베딩 생성 및 저장
+            logger.info(f"🔮 {len(chunks)}개 청크의 임베딩 생성 중...")
+            chunk_texts = [chunk.text for chunk in chunks]
+            chunk_metadatas = [chunk.metadata for chunk in chunks]
+            chunk_ids = [chunk.metadata.get("chunk_id", f"chunk_{i}") for i, chunk in enumerate(chunks)]
+            
+            # 임베딩 생성 (배치 처리)
+            batch_size = 50
+            all_embeddings = []
+            
+            for i in range(0, len(chunk_texts), batch_size):
+                batch_texts = chunk_texts[i : i + batch_size]
+                batch_num = (i // batch_size) + 1
+                total_batches = (len(chunk_texts) + batch_size - 1) // batch_size
+                
+                logger.info(f"📊 임베딩 배치 {batch_num}/{total_batches} 처리 중... ({len(batch_texts)}개 청크)")
+                
+                try:
+                    batch_embeddings = self.embedder.embed(batch_texts)
+                    all_embeddings.extend(batch_embeddings)
+                    logger.info(f"✅ 임베딩 배치 {batch_num}/{total_batches} 완료")
+                except Exception as e:
+                    logger.error(f"❌ 임베딩 배치 {batch_num} 처리 실패: {e}")
+                    continue
+            
+            if len(all_embeddings) != len(chunk_texts):
+                logger.warning(f"⚠️ 임베딩 개수 불일치: 청크 {len(chunk_texts)}개, 임베딩 {len(all_embeddings)}개")
+                valid_count = len(all_embeddings)
+                chunk_texts = chunk_texts[:valid_count]
+                chunk_metadatas = chunk_metadatas[:valid_count]
+                chunk_ids = chunk_ids[:valid_count]
+            
+            # 4. ChromaDB에 청크 단위 저장
+            logger.info(f"💾 {len(chunk_texts)}개 청크를 ChromaDB에 저장 중...")
+            chroma_batch_size = 100
+            
+            for i in range(0, len(chunk_texts), chroma_batch_size):
+                batch_texts = chunk_texts[i : i + chroma_batch_size]
+                batch_embeddings = all_embeddings[i : i + chroma_batch_size]
+                batch_ids = chunk_ids[i : i + chroma_batch_size]
+                batch_metadatas = chunk_metadatas[i : i + chroma_batch_size]
+                
+                batch_num = (i // chroma_batch_size) + 1
+                total_batches = (len(chunk_texts) + chroma_batch_size - 1) // chroma_batch_size
+                
+                logger.info(f"💾 ChromaDB 저장 배치 {batch_num}/{total_batches} 처리 중...")
+                
+                try:
+                    store_to_chroma(
+                        texts=batch_texts,
+                        embeddings=batch_embeddings,
+                        ids=batch_ids,
+                        metadatas=batch_metadatas,
+                        persist_dir=self.persist_dir,
+                    )
+                    logger.info(f"✅ ChromaDB 저장 배치 {batch_num}/{total_batches} 완료")
+                except Exception as e:
+                    logger.error(f"❌ ChromaDB 저장 배치 {batch_num} 실패: {e}")
+                    continue
+            
+            logger.info("✅ 벡터 데이터베이스 저장 완료!")
+            
+            # 처리 결과 요약
+            result = {
+                "success": True,
+                "pdf_files_processed": len(pdf_paths),
+                "json_records_processed": len(json_dict),
+                "total_documents": len(documents),
+                "total_chunks_stored": len(chunk_texts),
+                "chunks_per_document_avg": len(chunk_texts) / len(documents) if documents else 0,
+            }
+            
+            logger.info(f"🎉 데이터 처리 완료: {result}")
+            return result
+            
+        except Exception as e:
+            logger.error(f"❌ StructuredDocumentLoader 처리 중 오류 발생: {e}")
+            import traceback
+            traceback.print_exc()
+            return {
+                "success": False,
+                "error": str(e),
+                "pdf_files_processed": len(pdf_paths),
+                "json_records_processed": len(json_dict),
+                "total_chunks_stored": 0,
+            }
 
     def check_vector_store_status(self) -> Dict[str, Any]:
         """벡터 저장소 상태를 확인합니다."""

--- a/ingestion/src/services/data_processor.py
+++ b/ingestion/src/services/data_processor.py
@@ -1451,9 +1451,38 @@ class DataProcessor:
             
             # 3. 청크별 임베딩 생성
             logger.info(f"🔮 배치 {batch_num}: {len(chunks)}개 청크의 임베딩 생성 중...")
-            chunk_texts = [chunk.text for chunk in chunks]
-            chunk_metadatas = [chunk.metadata for chunk in chunks]
-            chunk_ids = [chunk.metadata.get("chunk_id", f"chunk_{i}") for i, chunk in enumerate(chunks)]
+            chunk_texts = []
+            chunk_metadatas = []
+            chunk_ids = []
+            
+            for chunk in chunks:
+                chunk_texts.append(chunk.text)
+                
+                # 청크 메타데이터 가져오기
+                metadata = chunk.metadata.copy()
+                
+                # 청크 ID 생성: {rec_idx}_{chunk_id} 형식 보장
+                rec_idx = metadata.get("rec_idx", "unknown")
+                chunk_id = metadata.get("chunk_id")
+                
+                if not chunk_id:
+                    # fallback: rec_idx가 없으면 인덱스 기반 생성
+                    chunk_id = f"{rec_idx}_chunk_{len(chunk_ids)}"
+                elif not chunk_id.startswith(rec_idx):
+                    # chunk_id에 rec_idx가 포함되지 않은 경우 추가
+                    chunk_id = f"{rec_idx}_{chunk_id}"
+                
+                # 메타데이터에 청크 ID 업데이트
+                metadata["chunk_id"] = chunk_id
+                
+                # 섹션 정보 메타데이터 확인 및 보강
+                if "section_type" not in metadata:
+                    metadata["section_type"] = "unknown"
+                if "section_length" not in metadata:
+                    metadata["section_length"] = len(chunk.text)
+                
+                chunk_metadatas.append(metadata)
+                chunk_ids.append(chunk_id)
             
             batch_size = 50
             all_embeddings = []

--- a/ingestion/src/services/data_processor.py
+++ b/ingestion/src/services/data_processor.py
@@ -595,11 +595,34 @@ class DataProcessor:
             else:
                 # 기존 방식: PyMuPDF 사용
                 return self._process_incremental_data_legacy(
-                    pdf_paths, json_dict, force_update
+                    pdf_paths, json_dict, force_update, s3_prefix, pdf_files, json_data
                 )
+        
+        except Exception as e:
+            logger.error(f"❌ 증분 데이터 처리 중 오류 발생: {e}")
+            return {
+                "success": False,
+                "error": str(e),
+                "added": 0,
+                "updated": 0,
+                "skipped": 0,
+            }
+        
+        finally:
+            # 임시 파일 정리
+            if pdf_paths:
+                self.s3_loader.cleanup_temp_files(pdf_paths)
+            if "temp_dir" in locals() and temp_dir.exists():
+                import shutil
+                try:
+                    shutil.rmtree(temp_dir)
+                    logger.info(f"🧹 임시 디렉토리 정리 완료: {temp_dir}")
+                except Exception as e:
+                    logger.warning(f"⚠️ 임시 디렉토리 정리 실패: {e}")
 
     def _process_incremental_data_legacy(
-        self, pdf_paths: List[Path], json_dict: Dict[str, Any], force_update: bool
+        self, pdf_paths: List[Path], json_dict: Dict[str, Any], force_update: bool,
+        s3_prefix: str, pdf_files: List[str], json_data: List[Any]
     ) -> Dict[str, Any]:
         """
         기존 방식: PyMuPDF를 사용한 증분 업데이트
@@ -608,6 +631,9 @@ class DataProcessor:
             pdf_paths: PDF 파일 경로 리스트
             json_dict: JSON 메타데이터 딕셔너리
             force_update: 중복 시 덮어쓰기 여부
+            s3_prefix: S3 경로 prefix
+            pdf_files: PDF 파일 목록
+            json_data: JSON 데이터 목록
             
         Returns:
             처리 결과 요약
@@ -618,7 +644,7 @@ class DataProcessor:
         pdf_metadatas = []
         pdf_ids = []
 
-            for pdf_path in pdf_paths:
+        for pdf_path in pdf_paths:
                 try:
                     raw_text = extract_text_PyMuPDF(pdf_path)
                     clean_text_result = clean_text(raw_text)
@@ -669,7 +695,7 @@ class DataProcessor:
                     logger.error(f"❌ PDF 처리 실패 {pdf_path.name}: {e}")
                     continue
 
-            # 5. 임베딩 생성 및 Upsert
+        # 5. 임베딩 생성 및 Upsert
             if pdf_documents:
                 logger.info(f"💾 {len(pdf_documents)}개 문서 처리 중...")
 
@@ -1145,4 +1171,282 @@ class DataProcessor:
                 "added": 0,
                 "updated": 0,
                 "skipped": 0,
+            }
+
+    def _process_batch_legacy(
+        self,
+        pdf_paths: List[Path],
+        json_dict: Dict[str, Any],
+        force_update: bool,
+        batch_num: int,
+    ) -> Dict[str, Any]:
+        """
+        기존 방식: PyMuPDF를 사용한 배치 처리
+        
+        Args:
+            pdf_paths: PDF 파일 경로 리스트
+            json_dict: JSON 메타데이터 딕셔너리
+            force_update: 중복 시 덮어쓰기 여부
+            batch_num: 배치 번호
+            
+        Returns:
+            처리 결과 요약
+        """
+        try:
+            logger.info(f"🔍 배치 {batch_num}: PDF 텍스트 추출 및 메타데이터 매칭 중... (기존 방식)")
+            pdf_documents = []
+            pdf_metadatas = []
+            pdf_ids = []
+
+            for pdf_path in pdf_paths:
+                try:
+                    raw_text = extract_text_PyMuPDF(pdf_path)
+                    clean_text_result = clean_text(raw_text)
+
+                    if clean_text_result.strip():
+                        pdf_filename = pdf_path.stem
+                        rec_idx = (
+                            pdf_filename.split("_")[-1]
+                            if "_" in pdf_filename
+                            else pdf_filename
+                        )
+
+                        json_metadata = json_dict.get(rec_idx)
+
+                        metadata = {
+                            "source": "pdf",
+                            "filename": pdf_path.name,
+                            "document_type": (
+                                "recruitment_pdf_with_json"
+                                if json_metadata
+                                else "recruitment_pdf_only"
+                            ),
+                            "rec_idx": rec_idx,
+                        }
+
+                        if json_metadata:
+                            for key, value in json_metadata.items():
+                                if isinstance(value, (str, int, float, bool)):
+                                    metadata[key] = str(value)
+
+                        pdf_documents.append(clean_text_result)
+                        pdf_metadatas.append(metadata)
+                        pdf_ids.append(rec_idx)
+
+                except Exception as e:
+                    logger.error(f"❌ PDF 처리 실패 {pdf_path.name}: {e}")
+                    continue
+
+            if not pdf_documents:
+                logger.warning(f"⚠️ 배치 {batch_num}: 처리할 문서가 없습니다.")
+                return {
+                    "success": False,
+                    "error": "No documents to process",
+                    "added": 0,
+                    "updated": 0,
+                    "skipped": 0,
+                    "total_processed": 0,
+                }
+
+            # 임베딩 생성
+            logger.info(f"🔮 배치 {batch_num}: 임베딩 생성 중... ({len(pdf_documents)}개 문서)")
+            batch_size = 50
+            all_embeddings = []
+
+            for i in range(0, len(pdf_documents), batch_size):
+                batch_docs = pdf_documents[i : i + batch_size]
+                batch_num_embed = (i // batch_size) + 1
+                total_batches = (len(pdf_documents) + batch_size - 1) // batch_size
+
+                try:
+                    batch_embeddings = self.embedder.embed(batch_docs)
+                    all_embeddings.extend(batch_embeddings)
+                except Exception as e:
+                    logger.error(f"❌ 배치 {batch_num} 임베딩 실패: {e}")
+                    continue
+
+            if len(all_embeddings) != len(pdf_documents):
+                logger.warning(
+                    f"⚠️ 배치 {batch_num}: 임베딩 개수 불일치: 문서 {len(pdf_documents)}개, 임베딩 {len(all_embeddings)}개"
+                )
+                valid_count = len(all_embeddings)
+                pdf_documents = pdf_documents[:valid_count]
+                pdf_metadatas = pdf_metadatas[:valid_count]
+                pdf_ids = pdf_ids[:valid_count]
+
+            # Upsert to ChromaDB
+            logger.info(f"💾 배치 {batch_num}: ChromaDB Upsert 중 (force_update={force_update})...")
+            upsert_result = upsert_to_chroma(
+                texts=pdf_documents,
+                embeddings=all_embeddings,
+                ids=pdf_ids,
+                metadatas=pdf_metadatas,
+                persist_dir=self.persist_dir,
+                force_update=force_update,
+            )
+
+            result = {
+                "success": True,
+                "added": upsert_result["added"],
+                "updated": upsert_result["updated"],
+                "skipped": upsert_result["skipped"],
+                "total_processed": len(pdf_documents),
+            }
+
+            return result
+
+        except Exception as e:
+            logger.error(f"❌ 배치 {batch_num} 처리 중 오류 발생: {e}")
+            return {
+                "success": False,
+                "error": str(e),
+                "added": 0,
+                "updated": 0,
+                "skipped": 0,
+                "total_processed": 0,
+            }
+
+    def _process_batch_with_structured_loader(
+        self,
+        pdf_paths: List[Path],
+        json_dict: Dict[str, Any],
+        force_update: bool,
+        batch_num: int,
+    ) -> Dict[str, Any]:
+        """
+        Experiment 전략: StructuredDocumentLoader를 사용한 배치 처리
+        
+        Args:
+            pdf_paths: PDF 파일 경로 리스트
+            json_dict: JSON 메타데이터 딕셔너리
+            force_update: 중복 시 덮어쓰기 여부
+            batch_num: 배치 번호
+            
+        Returns:
+            처리 결과 요약
+        """
+        try:
+            logger.info(f"🔍 배치 {batch_num}: StructuredDocumentLoader를 사용한 청크 단위 처리 시작...")
+            
+            # 1. 문서 리스트 생성
+            documents = []
+            
+            for pdf_path in pdf_paths:
+                try:
+                    raw_text = extract_text_PyMuPDF(pdf_path)
+                    clean_text_result = clean_text(raw_text)
+                    
+                    if not clean_text_result.strip():
+                        continue
+                    
+                    pdf_filename = pdf_path.stem
+                    rec_idx = (
+                        pdf_filename.split("_")[-1]
+                        if "_" in pdf_filename
+                        else pdf_filename
+                    )
+                    
+                    json_metadata = json_dict.get(rec_idx, {})
+                    
+                    doc_item = {
+                        "text": clean_text_result,
+                        "metadata": {
+                            "source": "pdf",
+                            "filename": pdf_path.name,
+                            "document_type": "recruitment_pdf_with_json" if json_metadata else "recruitment_pdf_only",
+                            "rec_idx": rec_idx,
+                            **json_metadata,
+                        }
+                    }
+                    
+                    documents.append(doc_item)
+                    
+                except Exception as e:
+                    logger.error(f"❌ PDF 처리 실패 {pdf_path.name}: {e}")
+                    continue
+            
+            if not documents:
+                logger.warning(f"⚠️ 배치 {batch_num}: 처리할 문서가 없습니다.")
+                return {
+                    "success": False,
+                    "error": "No documents to process",
+                    "added": 0,
+                    "updated": 0,
+                    "skipped": 0,
+                    "total_processed": 0,
+                }
+            
+            # 2. StructuredDocumentLoader로 청크 생성
+            logger.info(f"📦 배치 {batch_num}: {len(documents)}개 문서에서 청크 생성 중...")
+            chunks = self.structured_loader.load_from_documents(documents)
+            
+            if not chunks:
+                logger.warning(f"⚠️ 배치 {batch_num}: 생성된 청크가 없습니다.")
+                return {
+                    "success": False,
+                    "error": "No chunks generated",
+                    "added": 0,
+                    "updated": 0,
+                    "skipped": 0,
+                    "total_processed": 0,
+                }
+            
+            # 3. 청크별 임베딩 생성
+            logger.info(f"🔮 배치 {batch_num}: {len(chunks)}개 청크의 임베딩 생성 중...")
+            chunk_texts = [chunk.text for chunk in chunks]
+            chunk_metadatas = [chunk.metadata for chunk in chunks]
+            chunk_ids = [chunk.metadata.get("chunk_id", f"chunk_{i}") for i, chunk in enumerate(chunks)]
+            
+            batch_size = 50
+            all_embeddings = []
+            
+            for i in range(0, len(chunk_texts), batch_size):
+                batch_texts = chunk_texts[i : i + batch_size]
+                
+                try:
+                    batch_embeddings = self.embedder.embed(batch_texts)
+                    all_embeddings.extend(batch_embeddings)
+                except Exception as e:
+                    logger.error(f"❌ 배치 {batch_num} 임베딩 실패: {e}")
+                    continue
+            
+            if len(all_embeddings) != len(chunk_texts):
+                logger.warning(f"⚠️ 배치 {batch_num}: 임베딩 개수 불일치: 청크 {len(chunk_texts)}개, 임베딩 {len(all_embeddings)}개")
+                valid_count = len(all_embeddings)
+                chunk_texts = chunk_texts[:valid_count]
+                chunk_metadatas = chunk_metadatas[:valid_count]
+                chunk_ids = chunk_ids[:valid_count]
+            
+            # 4. ChromaDB에 청크 단위 Upsert
+            logger.info(f"💾 배치 {batch_num}: {len(chunk_texts)}개 청크를 ChromaDB에 Upsert 중... (force_update={force_update})")
+            upsert_result = upsert_to_chroma(
+                texts=chunk_texts,
+                embeddings=all_embeddings,
+                ids=chunk_ids,
+                metadatas=chunk_metadatas,
+                persist_dir=self.persist_dir,
+                force_update=force_update,
+            )
+            
+            result = {
+                "success": True,
+                "added": upsert_result["added"],
+                "updated": upsert_result["updated"],
+                "skipped": upsert_result["skipped"],
+                "total_processed": len(chunk_texts),
+            }
+            
+            return result
+            
+        except Exception as e:
+            logger.error(f"❌ 배치 {batch_num} StructuredDocumentLoader 처리 중 오류 발생: {e}")
+            import traceback
+            traceback.print_exc()
+            return {
+                "success": False,
+                "error": str(e),
+                "added": 0,
+                "updated": 0,
+                "skipped": 0,
+                "total_processed": 0,
             }

--- a/ingestion/src/services/data_processor.py
+++ b/ingestion/src/services/data_processor.py
@@ -82,7 +82,22 @@ class DataProcessor:
                 )
             else:
                 # 기존 방식: PyMuPDF 사용
-                return self._process_s3_data_legacy(pdf_paths, json_dict)
+                return self._process_s3_data_legacy(pdf_paths, json_dict, json_data)
+            
+        except Exception as e:
+            logger.error(f"❌ 데이터 처리 중 오류 발생: {e}")
+            return {
+                "success": False,
+                "error": str(e),
+                "pdf_files_processed": 0,
+                "json_records_processed": 0,
+                "total_documents_stored": 0,
+            }
+            
+        finally:
+            # 임시 파일 정리
+            if pdf_paths:
+                self.s3_loader.cleanup_temp_files(pdf_paths)
 
     def _process_s3_data_legacy(
         self, pdf_paths: List[Path], json_dict: Dict[str, Any]
@@ -102,7 +117,7 @@ class DataProcessor:
         pdf_documents = []
         pdf_metadatas = []
 
-            for pdf_path in pdf_paths:
+        for pdf_path in pdf_paths:
                 try:
                     # 텍스트 추출
                     raw_text = extract_text_PyMuPDF(pdf_path)

--- a/ingestion/src/services/data_processor.py
+++ b/ingestion/src/services/data_processor.py
@@ -1064,102 +1064,31 @@ class DataProcessor:
 
                     logger.info(f"📋 {len(json_dict)}개의 JSON 레코드 인덱싱 완료")
 
-                    # PDF 텍스트 추출 및 메타데이터 매칭
-                    logger.info("🔍 PDF 텍스트 추출 및 메타데이터 매칭 중...")
-                    pdf_documents = []
-                    pdf_metadatas = []
-                    pdf_ids = []
-
-                    for pdf_path in pdf_paths:
-                        try:
-                            raw_text = extract_text_PyMuPDF(pdf_path)
-                            clean_text_result = clean_text(raw_text)
-
-                            if clean_text_result.strip():
-                                pdf_filename = pdf_path.stem
-                                rec_idx = (
-                                    pdf_filename.split("_")[-1]
-                                    if "_" in pdf_filename
-                                    else pdf_filename
-                                )
-
-                                json_metadata = json_dict.get(rec_idx)
-
-                                metadata = {
-                                    "source": "pdf",
-                                    "filename": pdf_path.name,
-                                    "document_type": (
-                                        "recruitment_pdf_with_json"
-                                        if json_metadata
-                                        else "recruitment_pdf_only"
-                                    ),
-                                    "rec_idx": rec_idx,
-                                }
-
-                                if json_metadata:
-                                    for key, value in json_metadata.items():
-                                        if isinstance(value, (str, int, float, bool)):
-                                            metadata[key] = str(value)
-                                    logger.info(
-                                        f"✅ 매칭: {rec_idx} - {json_metadata.get('post_title', 'Unknown')[:30]}..."
-                                    )
-                                else:
-                                    metadata.update(
-                                        {
-                                            "post_title": "제목 없음",
-                                            "deadline": "미정",
-                                            "detail_url": "",
-                                        }
-                                    )
-
-                                pdf_documents.append(clean_text_result)
-                                pdf_metadatas.append(metadata)
-                                pdf_ids.append(rec_idx)
-
-                        except Exception as e:
-                            logger.error(f"❌ PDF 처리 실패 {pdf_path.name}: {e}")
-                            continue
-
-                    # 임베딩 생성 및 Upsert (배치 내에서는 한번에 처리)
-                    if pdf_documents:
-                        logger.info(
-                            f"🔮 임베딩 생성 중... ({len(pdf_documents)}개 문서)"
+                    # StructuredDocumentLoader 사용 여부에 따라 처리 방식 분기
+                    if self.use_structured_loader and self.structured_loader:
+                        # Experiment 전략: StructuredDocumentLoader 사용
+                        batch_result = self._process_batch_with_structured_loader(
+                            pdf_paths, json_dict, force_update, batch_num
                         )
-
-                        try:
-                            # 임베딩 생성
-                            batch_embeddings = self.embedder.embed(pdf_documents)
-
-                            # ChromaDB Upsert
-                            logger.info(f"💾 ChromaDB Upsert 중...")
-                            upsert_result = upsert_to_chroma(
-                                texts=pdf_documents,
-                                embeddings=batch_embeddings,
-                                ids=pdf_ids,
-                                metadatas=pdf_metadatas,
-                                persist_dir=self.persist_dir,
-                                force_update=force_update,
-                            )
-
-                            # 통계 누적
-                            total_added += upsert_result["added"]
-                            total_updated += upsert_result["updated"]
-                            total_skipped += upsert_result["skipped"]
-                            total_processed += len(pdf_documents)
-
-                            logger.info(
-                                f"✅ 배치 {batch_num}/{total_batches} 완료: "
-                                f"추가 {upsert_result['added']}, "
-                                f"업데이트 {upsert_result['updated']}, "
-                                f"스킵 {upsert_result['skipped']}"
-                            )
-
-                        except Exception as e:
-                            logger.error(f"❌ 배치 {batch_num} 임베딩/Upsert 실패: {e}")
-                            continue
-
                     else:
-                        logger.warning(f"⚠️  배치 {batch_num}: 처리할 문서 없음")
+                        # 기존 방식: PyMuPDF 사용
+                        batch_result = self._process_batch_legacy(
+                            pdf_paths, json_dict, force_update, batch_num
+                        )
+                    
+                    # 통계 누적
+                    if batch_result.get("success"):
+                        total_added += batch_result.get("added", 0)
+                        total_updated += batch_result.get("updated", 0)
+                        total_skipped += batch_result.get("skipped", 0)
+                        total_processed += batch_result.get("total_processed", 0)
+                        
+                        logger.info(
+                            f"✅ 배치 {batch_num}/{total_batches} 완료: "
+                            f"추가 {batch_result.get('added', 0)}, "
+                            f"업데이트 {batch_result.get('updated', 0)}, "
+                            f"스킵 {batch_result.get('skipped', 0)}"
+                        )
 
                 finally:
                     # 배치별 메모리 해제

--- a/ingestion/src/services/data_processor.py
+++ b/ingestion/src/services/data_processor.py
@@ -1,102 +1,125 @@
 """
 S3 데이터를 로드하고 처리하는 통합 서비스
 """
+
 import os
 from typing import List, Dict, Any
 from pathlib import Path
 import logging
 
 from storage import S3DataLoader, store_to_chroma, upsert_to_chroma, query_chroma
-from preprocessing import extract_text_PyMuPDF, clean_text
+from preprocessing import extract_text_PyMuPDF, clean_text, StructuredDocumentLoader
 from .embedder import OpenAITextEmbedder
 
 logger = logging.getLogger(__name__)
 
+
 class DataProcessor:
-    def __init__(self):
-        """데이터 처리기 초기화"""
+    def __init__(self, use_structured_loader: bool = True):
+        """
+        데이터 처리기 초기화
+
+        Args:
+            use_structured_loader: StructuredDocumentLoader 사용 여부
+                True: Experiment 전략 (섹션별 청킹)
+                False: 기존 방식 (전체 문서 단위)
+        """
         self.s3_loader = S3DataLoader()
         self.embedder = OpenAITextEmbedder()
+        self.use_structured_loader = use_structured_loader
+
+        # StructuredDocumentLoader 초기화 (Experiment 전략)
+        if self.use_structured_loader:
+            self.structured_loader = StructuredDocumentLoader(
+                strategy="fast",
+                target_sections=["preferred", "qualifications", "job_duties"],
+                include_context=True,
+            )
+        else:
+            self.structured_loader = None
+
         # 환경변수를 통한 벡터 저장소 경로 설정
         self.persist_dir = os.getenv(
-            "VECTOR_STORE_PATH", 
-            "/app/data/vector_store_pymupdf_text-embedding-ada-002_chroma"
+            "VECTOR_STORE_PATH",
+            "/app/data/vector_store_pymupdf_text-embedding-ada-002_chroma",
         )
-        
+
     def process_s3_data(self) -> Dict[str, Any]:
         """
         S3에서 데이터를 로드하고 벡터 데이터베이스에 저장합니다.
-        
+
         Returns:
             Dict[str, Any]: 처리 결과 요약
         """
         pdf_paths = []
         try:
             logger.info("🚀 S3 데이터 처리 시작...")
-            
+
             # 1. S3에서 PDF 파일 다운로드
             logger.info("📄 S3에서 PDF 파일 다운로드 중...")
             pdf_paths = self.s3_loader.download_pdf_files()
-            
+
             # 2. S3에서 JSON 파일 로드
             logger.info("📊 S3에서 JSON 파일 로드 중...")
             json_data = self.s3_loader.load_json_files()
-            
+
             # 3. JSON 데이터를 딕셔너리로 변환 (파일명 기준 매칭용)
             logger.info("📊 JSON 데이터 인덱싱 중...")
             json_dict = {}
             for item in json_data:
-                if isinstance(item, dict) and 'rec_idx' in item:
+                if isinstance(item, dict) and "rec_idx" in item:
                     # JSON 파일명에서 rec_idx 추출하여 키로 사용
-                    rec_idx = item['rec_idx']
+                    rec_idx = item["rec_idx"]
                     json_dict[rec_idx] = item
-            
+
             logger.info(f"📋 {len(json_dict)}개의 JSON 레코드 인덱싱 완료")
 
             # 4. PDF 텍스트 추출 및 JSON 메타데이터 매칭
             logger.info("🔍 PDF 텍스트 추출 및 JSON 메타데이터 매칭 중...")
             pdf_documents = []
             pdf_metadatas = []
-            
+
             for pdf_path in pdf_paths:
                 try:
                     # 텍스트 추출
                     raw_text = extract_text_PyMuPDF(pdf_path)
-                    
+
                     # 텍스트 정리
                     clean_text_result = clean_text(raw_text)
-                    
+
                     if clean_text_result.strip():
                         # PDF 파일명에서 rec_idx 추출 (예: 20250417_49421173.pdf -> 49421173)
                         pdf_filename = pdf_path.stem  # 확장자 제거
-                        
+
                         # 파일명에서 rec_idx 추출 (마지막 '_' 이후 부분)
-                        if '_' in pdf_filename:
-                            rec_idx = pdf_filename.split('_')[-1]
+                        if "_" in pdf_filename:
+                            rec_idx = pdf_filename.split("_")[-1]
                         else:
                             rec_idx = pdf_filename
-                        
+
                         # 해당 JSON 메타데이터 찾기
                         json_metadata = json_dict.get(rec_idx)
-                        
+
                         if json_metadata:
                             # JSON 메타데이터와 함께 저장
                             metadata = {
                                 "source": "pdf",
                                 "filename": pdf_path.name,
                                 "document_type": "recruitment_pdf_with_json",
-                                "rec_idx": rec_idx
+                                "rec_idx": rec_idx,
                             }
-                            
+
                             # JSON의 모든 필드를 메타데이터에 추가
                             for key, value in json_metadata.items():
                                 if isinstance(value, (str, int, float, bool)):
                                     metadata[key] = str(value)
-                            
+
                             pdf_documents.append(clean_text_result)
                             pdf_metadatas.append(metadata)
-                            
-                            logger.info(f"✅ PDF {pdf_path.name} + JSON 메타데이터 매칭 완료: {json_metadata.get('post_title', 'Unknown')}")
+
+                            logger.info(
+                                f"✅ PDF {pdf_path.name} + JSON 메타데이터 매칭 완료: {json_metadata.get('post_title', 'Unknown')}"
+                            )
                         else:
                             # 매칭되는 JSON이 없는 경우 PDF만 저장
                             metadata = {
@@ -106,14 +129,16 @@ class DataProcessor:
                                 "rec_idx": rec_idx,
                                 "post_title": "제목 없음",
                                 "deadline": "미정",
-                                "detail_url": ""
+                                "detail_url": "",
                             }
-                            
+
                             pdf_documents.append(clean_text_result)
                             pdf_metadatas.append(metadata)
-                            
-                            logger.warning(f"⚠️ PDF {pdf_path.name}에 매칭되는 JSON 없음 (rec_idx: {rec_idx})")
-                        
+
+                            logger.warning(
+                                f"⚠️ PDF {pdf_path.name}에 매칭되는 JSON 없음 (rec_idx: {rec_idx})"
+                            )
+
                 except Exception as e:
                     logger.error(f"❌ PDF 처리 실패 {pdf_path.name}: {e}")
                     continue
@@ -121,22 +146,26 @@ class DataProcessor:
             # 5. 벡터 데이터베이스에 저장 (PDF + JSON 매칭 데이터만)
             all_documents = pdf_documents  # JSON 별개 문서 제거
             all_metadatas = pdf_metadatas  # JSON 별개 메타데이터 제거
-            
+
             if all_documents:
-                logger.info(f"💾 벡터 데이터베이스에 {len(all_documents)}개 문서 저장 중...")
-                
+                logger.info(
+                    f"💾 벡터 데이터베이스에 {len(all_documents)}개 문서 저장 중..."
+                )
+
                 # 임베딩 생성 (배치 처리)
                 logger.info("🔮 임베딩 생성 중...")
                 batch_size = 50  # 배치 크기 설정
                 all_embeddings = []
-                
+
                 for i in range(0, len(all_documents), batch_size):
-                    batch_docs = all_documents[i:i + batch_size]
+                    batch_docs = all_documents[i : i + batch_size]
                     batch_num = (i // batch_size) + 1
                     total_batches = (len(all_documents) + batch_size - 1) // batch_size
-                    
-                    logger.info(f"📊 배치 {batch_num}/{total_batches} 처리 중... ({len(batch_docs)}개 문서)")
-                    
+
+                    logger.info(
+                        f"📊 배치 {batch_num}/{total_batches} 처리 중... ({len(batch_docs)}개 문서)"
+                    )
+
                     try:
                         batch_embeddings = self.embedder.embed(batch_docs)
                         all_embeddings.extend(batch_embeddings)
@@ -146,50 +175,58 @@ class DataProcessor:
                         # 실패한 배치는 건너뛰고 계속 진행
                         # 해당 배치만큼 빈 임베딩으로 채우기 (또는 다른 처리)
                         continue
-                
+
                 if len(all_embeddings) != len(all_documents):
-                    logger.warning(f"⚠️ 임베딩 개수 불일치: 문서 {len(all_documents)}개, 임베딩 {len(all_embeddings)}개")
+                    logger.warning(
+                        f"⚠️ 임베딩 개수 불일치: 문서 {len(all_documents)}개, 임베딩 {len(all_embeddings)}개"
+                    )
                     # 임베딩에 실패한 문서들 제거
                     valid_count = len(all_embeddings)
                     all_documents = all_documents[:valid_count]
                     all_metadatas = all_metadatas[:valid_count]
-                
+
                 # 문서 ID 생성
                 ids = [f"doc_{i}" for i in range(len(all_documents))]
-                
+
                 # Chroma에 저장 (배치 처리)
                 logger.info(f"💾 {len(all_documents)}개 문서를 Chroma에 저장 중...")
                 chroma_batch_size = 100  # Chroma 저장 배치 크기
-                
+
                 for i in range(0, len(all_documents), chroma_batch_size):
-                    batch_docs = all_documents[i:i + chroma_batch_size]
-                    batch_embeddings = all_embeddings[i:i + chroma_batch_size]
-                    batch_ids = ids[i:i + chroma_batch_size]
-                    batch_metadatas = all_metadatas[i:i + chroma_batch_size]
-                    
+                    batch_docs = all_documents[i : i + chroma_batch_size]
+                    batch_embeddings = all_embeddings[i : i + chroma_batch_size]
+                    batch_ids = ids[i : i + chroma_batch_size]
+                    batch_metadatas = all_metadatas[i : i + chroma_batch_size]
+
                     batch_num = (i // chroma_batch_size) + 1
-                    total_batches = (len(all_documents) + chroma_batch_size - 1) // chroma_batch_size
-                    
-                    logger.info(f"💾 Chroma 저장 배치 {batch_num}/{total_batches} 처리 중...")
-                    
+                    total_batches = (
+                        len(all_documents) + chroma_batch_size - 1
+                    ) // chroma_batch_size
+
+                    logger.info(
+                        f"💾 Chroma 저장 배치 {batch_num}/{total_batches} 처리 중..."
+                    )
+
                     try:
                         store_to_chroma(
                             texts=batch_docs,
                             embeddings=batch_embeddings,
                             ids=batch_ids,
                             metadatas=batch_metadatas,
-                            persist_dir=self.persist_dir
+                            persist_dir=self.persist_dir,
                         )
-                        logger.info(f"✅ Chroma 저장 배치 {batch_num}/{total_batches} 완료")
+                        logger.info(
+                            f"✅ Chroma 저장 배치 {batch_num}/{total_batches} 완료"
+                        )
                     except Exception as e:
                         logger.error(f"❌ Chroma 저장 배치 {batch_num} 실패: {e}")
                         # 저장 실패시에도 계속 진행
                         continue
-                
+
                 logger.info("✅ 벡터 데이터베이스 저장 완료!")
             else:
                 logger.warning("⚠️ 처리할 문서가 없습니다.")
-            
+
             # 처리 결과 요약
             result = {
                 "success": True,
@@ -197,12 +234,12 @@ class DataProcessor:
                 "json_records_processed": len(json_data),
                 "total_pdf_documents": len(pdf_documents),
                 "total_json_documents": 0,
-                "total_documents_stored": len(all_documents)
+                "total_documents_stored": len(all_documents),
             }
-            
+
             logger.info(f"🎉 데이터 처리 완료: {result}")
             return result
-            
+
         except Exception as e:
             logger.error(f"❌ 데이터 처리 중 오류 발생: {e}")
             return {
@@ -210,9 +247,9 @@ class DataProcessor:
                 "error": str(e),
                 "pdf_files_processed": 0,
                 "json_records_processed": 0,
-                "total_documents_stored": 0
+                "total_documents_stored": 0,
             }
-            
+
         finally:
             # 임시 파일 정리
             if pdf_paths:
@@ -226,30 +263,27 @@ class DataProcessor:
                 query="테스트",
                 embedder=self.embedder,
                 persist_dir=self.persist_dir,
-                top_k=1
+                top_k=1,
             )
-            
-            if results and results.get('documents'):
-                document_count = len(results['documents'][0]) if results['documents'][0] else 0
+
+            if results and results.get("documents"):
+                document_count = (
+                    len(results["documents"][0]) if results["documents"][0] else 0
+                )
                 return {
                     "status": "available",
                     "sample_document_count": document_count,
-                    "persist_dir": self.persist_dir
+                    "persist_dir": self.persist_dir,
                 }
             else:
-                return {
-                    "status": "empty",
-                    "persist_dir": self.persist_dir
-                }
-                
-        except Exception as e:
-            return {
-                "status": "error",
-                "error": str(e),
-                "persist_dir": self.persist_dir
-            }
+                return {"status": "empty", "persist_dir": self.persist_dir}
 
-    def process_incremental_data(self, s3_prefix: str, force_update: bool = False) -> Dict[str, Any]:
+        except Exception as e:
+            return {"status": "error", "error": str(e), "persist_dir": self.persist_dir}
+
+    def process_incremental_data(
+        self, s3_prefix: str, force_update: bool = False
+    ) -> Dict[str, Any]:
         """
         S3의 특정 경로에서 데이터를 로드하고 증분 업데이트 (upsert)
 
@@ -272,15 +306,23 @@ class DataProcessor:
             original_json_prefix = "initial-dataset/json/"
 
             # S3 prefix에 맞게 PDF/JSON 다운로드
-            pdf_prefix = f"{s3_prefix}pdf/" if not s3_prefix.endswith('/') else f"{s3_prefix}pdf/"
-            json_prefix = f"{s3_prefix}json/" if not s3_prefix.endswith('/') else f"{s3_prefix}json/"
+            pdf_prefix = (
+                f"{s3_prefix}pdf/"
+                if not s3_prefix.endswith("/")
+                else f"{s3_prefix}pdf/"
+            )
+            json_prefix = (
+                f"{s3_prefix}json/"
+                if not s3_prefix.endswith("/")
+                else f"{s3_prefix}json/"
+            )
 
             # S3에서 파일 목록 조회
             pdf_objects = self.s3_loader.list_s3_objects(pdf_prefix)
             json_objects = self.s3_loader.list_s3_objects(json_prefix)
 
-            pdf_files = [obj for obj in pdf_objects if obj.endswith('.pdf')]
-            json_files = [obj for obj in json_objects if obj.endswith('.json')]
+            pdf_files = [obj for obj in pdf_objects if obj.endswith(".pdf")]
+            json_files = [obj for obj in json_objects if obj.endswith(".json")]
 
             if not pdf_files:
                 logger.warning(f"⚠️  S3 경로에 PDF 파일이 없습니다: {pdf_prefix}")
@@ -289,7 +331,7 @@ class DataProcessor:
                     "error": "No PDF files found in S3",
                     "added": 0,
                     "updated": 0,
-                    "skipped": 0
+                    "skipped": 0,
                 }
 
             logger.info(f"✅ {len(pdf_files)}개의 PDF 파일 발견")
@@ -297,6 +339,7 @@ class DataProcessor:
             # 임시 디렉토리 생성
             from pathlib import Path
             import tempfile
+
             temp_dir = Path(tempfile.mkdtemp(prefix="career_hi_incremental_"))
             downloaded_pdf_paths = []
 
@@ -306,9 +349,7 @@ class DataProcessor:
                 local_path = temp_dir / filename
 
                 self.s3_loader.s3_client.download_file(
-                    self.s3_loader.bucket_name,
-                    pdf_key,
-                    str(local_path)
+                    self.s3_loader.bucket_name, pdf_key, str(local_path)
                 )
                 downloaded_pdf_paths.append(local_path)
                 logger.info(f"✅ PDF 다운로드: {filename}")
@@ -321,11 +362,11 @@ class DataProcessor:
 
             for json_key in json_files:
                 response = self.s3_loader.s3_client.get_object(
-                    Bucket=self.s3_loader.bucket_name,
-                    Key=json_key
+                    Bucket=self.s3_loader.bucket_name, Key=json_key
                 )
-                content = response['Body'].read().decode('utf-8')
+                content = response["Body"].read().decode("utf-8")
                 import json as json_module
+
                 data = json_module.loads(content)
 
                 if isinstance(data, list):
@@ -338,8 +379,8 @@ class DataProcessor:
             # 3. JSON 데이터 인덱싱
             json_dict = {}
             for item in json_data:
-                if isinstance(item, dict) and 'rec_idx' in item:
-                    rec_idx = item['rec_idx']
+                if isinstance(item, dict) and "rec_idx" in item:
+                    rec_idx = item["rec_idx"]
                     json_dict[rec_idx] = item
 
             logger.info(f"📋 {len(json_dict)}개의 JSON 레코드 인덱싱 완료")
@@ -357,28 +398,40 @@ class DataProcessor:
 
                     if clean_text_result.strip():
                         pdf_filename = pdf_path.stem
-                        rec_idx = pdf_filename.split('_')[-1] if '_' in pdf_filename else pdf_filename
+                        rec_idx = (
+                            pdf_filename.split("_")[-1]
+                            if "_" in pdf_filename
+                            else pdf_filename
+                        )
 
                         json_metadata = json_dict.get(rec_idx)
 
                         metadata = {
                             "source": "pdf",
                             "filename": pdf_path.name,
-                            "document_type": "recruitment_pdf_with_json" if json_metadata else "recruitment_pdf_only",
-                            "rec_idx": rec_idx
+                            "document_type": (
+                                "recruitment_pdf_with_json"
+                                if json_metadata
+                                else "recruitment_pdf_only"
+                            ),
+                            "rec_idx": rec_idx,
                         }
 
                         if json_metadata:
                             for key, value in json_metadata.items():
                                 if isinstance(value, (str, int, float, bool)):
                                     metadata[key] = str(value)
-                            logger.info(f"✅ 매칭 완료: {rec_idx} - {json_metadata.get('post_title', 'Unknown')}")
+                            logger.info(
+                                f"✅ 매칭 완료: {rec_idx} - {json_metadata.get('post_title', 'Unknown')}"
+                            )
                         else:
-                            metadata.update({
-                                "post_title": "제목 없음",
-                                "deadline": "미정",
-                                "detail_url": ""
-                            })
+                            metadata.update(
+                                {
+                                    "post_title": "제목 없음",
+                                    "deadline": "미정",
+                                    "detail_url": "",
+                                }
+                            )
                             logger.warning(f"⚠️  JSON 없음: {rec_idx}")
 
                         pdf_documents.append(clean_text_result)
@@ -399,11 +452,13 @@ class DataProcessor:
                 all_embeddings = []
 
                 for i in range(0, len(pdf_documents), batch_size):
-                    batch_docs = pdf_documents[i:i + batch_size]
+                    batch_docs = pdf_documents[i : i + batch_size]
                     batch_num = (i // batch_size) + 1
                     total_batches = (len(pdf_documents) + batch_size - 1) // batch_size
 
-                    logger.info(f"📊 배치 {batch_num}/{total_batches} 처리 중... ({len(batch_docs)}개 문서)")
+                    logger.info(
+                        f"📊 배치 {batch_num}/{total_batches} 처리 중... ({len(batch_docs)}개 문서)"
+                    )
 
                     try:
                         batch_embeddings = self.embedder.embed(batch_docs)
@@ -414,7 +469,9 @@ class DataProcessor:
                         continue
 
                 if len(all_embeddings) != len(pdf_documents):
-                    logger.warning(f"⚠️  임베딩 개수 불일치: 문서 {len(pdf_documents)}개, 임베딩 {len(all_embeddings)}개")
+                    logger.warning(
+                        f"⚠️  임베딩 개수 불일치: 문서 {len(pdf_documents)}개, 임베딩 {len(all_embeddings)}개"
+                    )
                     valid_count = len(all_embeddings)
                     pdf_documents = pdf_documents[:valid_count]
                     pdf_metadatas = pdf_metadatas[:valid_count]
@@ -428,7 +485,7 @@ class DataProcessor:
                     ids=pdf_ids,
                     metadatas=pdf_metadatas,
                     persist_dir=self.persist_dir,
-                    force_update=force_update
+                    force_update=force_update,
                 )
 
                 result = {
@@ -439,7 +496,7 @@ class DataProcessor:
                     "added": upsert_result["added"],
                     "updated": upsert_result["updated"],
                     "skipped": upsert_result["skipped"],
-                    "total_processed": len(pdf_documents)
+                    "total_processed": len(pdf_documents),
                 }
 
                 logger.info(f"🎉 증분 데이터 처리 완료: {result}")
@@ -452,7 +509,7 @@ class DataProcessor:
                     "error": "No documents to process",
                     "added": 0,
                     "updated": 0,
-                    "skipped": 0
+                    "skipped": 0,
                 }
 
         except Exception as e:
@@ -462,13 +519,14 @@ class DataProcessor:
                 "error": str(e),
                 "added": 0,
                 "updated": 0,
-                "skipped": 0
+                "skipped": 0,
             }
 
         finally:
             # 임시 파일 정리
             if pdf_paths:
-                self.s3_loader.cleanup_temp_files(pdf_paths) 
+                self.s3_loader.cleanup_temp_files(pdf_paths)
+
     def find_s3_files_by_rec_idx(self, rec_idx: str) -> Dict[str, str]:
         """
         S3에서 특정 rec_idx의 PDF/JSON 파일을 찾습니다 (날짜별 디렉토리 구조)
@@ -505,7 +563,9 @@ class DataProcessor:
                     break
 
             if pdf_key or json_key:
-                logger.info(f"✅ rec_idx {rec_idx} 파일 발견: PDF={bool(pdf_key)}, JSON={bool(json_key)}")
+                logger.info(
+                    f"✅ rec_idx {rec_idx} 파일 발견: PDF={bool(pdf_key)}, JSON={bool(json_key)}"
+                )
                 return {"pdf_key": pdf_key, "json_key": json_key}
             else:
                 logger.warning(f"⚠️  rec_idx {rec_idx} 파일을 찾을 수 없습니다")
@@ -515,7 +575,9 @@ class DataProcessor:
             logger.error(f"❌ rec_idx {rec_idx} 파일 검색 실패: {e}")
             return {}
 
-    def process_by_rec_idx_list(self, rec_idx_list: List[str], force_update: bool = False) -> Dict[str, Any]:
+    def process_by_rec_idx_list(
+        self, rec_idx_list: List[str], force_update: bool = False
+    ) -> Dict[str, Any]:
         """
         특정 rec_idx 리스트를 S3에서 찾아 처리합니다 (크롤러 연동용)
 
@@ -535,7 +597,9 @@ class DataProcessor:
         import gc
 
         try:
-            logger.info(f"🚀 rec_idx 리스트 처리 시작 ({len(rec_idx_list)}개) - 배치 처리 모드")
+            logger.info(
+                f"🚀 rec_idx 리스트 처리 시작 ({len(rec_idx_list)}개) - 배치 처리 모드"
+            )
 
             if not rec_idx_list:
                 return {
@@ -543,7 +607,7 @@ class DataProcessor:
                     "error": "Empty rec_idx_list",
                     "added": 0,
                     "updated": 0,
-                    "skipped": 0
+                    "skipped": 0,
                 }
 
             # 전체 통계
@@ -556,15 +620,19 @@ class DataProcessor:
             BATCH_SIZE = 50
             total_batches = (len(rec_idx_list) + BATCH_SIZE - 1) // BATCH_SIZE
 
-            logger.info(f"📦 총 {total_batches}개 배치로 처리 예정 (배치 크기: {BATCH_SIZE})")
+            logger.info(
+                f"📦 총 {total_batches}개 배치로 처리 예정 (배치 크기: {BATCH_SIZE})"
+            )
 
             # rec_idx_list를 배치로 분할 처리
             for batch_idx in range(0, len(rec_idx_list), BATCH_SIZE):
-                batch_rec_ids = rec_idx_list[batch_idx:batch_idx + BATCH_SIZE]
+                batch_rec_ids = rec_idx_list[batch_idx : batch_idx + BATCH_SIZE]
                 batch_num = (batch_idx // BATCH_SIZE) + 1
 
                 logger.info(f"\n{'='*60}")
-                logger.info(f"📦 배치 {batch_num}/{total_batches} 시작 ({len(batch_rec_ids)}개)")
+                logger.info(
+                    f"📦 배치 {batch_num}/{total_batches} 시작 ({len(batch_rec_ids)}개)"
+                )
                 logger.info(f"{'='*60}")
 
                 # 배치별 임시 디렉토리 생성
@@ -581,32 +649,30 @@ class DataProcessor:
                             # S3에서 PDF/JSON 파일 찾기
                             files = self.find_s3_files_by_rec_idx(rec_idx)
 
-                            if not files.get('pdf_key'):
+                            if not files.get("pdf_key"):
                                 logger.warning(f"⚠️  rec_idx {rec_idx}: PDF 없음, 스킵")
                                 continue
 
                             # PDF 다운로드
-                            pdf_key = files['pdf_key']
+                            pdf_key = files["pdf_key"]
                             filename = Path(pdf_key).name
                             local_pdf_path = temp_dir / filename
 
                             self.s3_loader.s3_client.download_file(
-                                self.s3_loader.bucket_name,
-                                pdf_key,
-                                str(local_pdf_path)
+                                self.s3_loader.bucket_name, pdf_key, str(local_pdf_path)
                             )
                             downloaded_pdf_paths.append(local_pdf_path)
                             logger.info(f"✅ PDF 다운로드: {filename}")
 
                             # JSON 다운로드 (있으면)
-                            if files.get('json_key'):
-                                json_key = files['json_key']
+                            if files.get("json_key"):
+                                json_key = files["json_key"]
                                 response = self.s3_loader.s3_client.get_object(
-                                    Bucket=self.s3_loader.bucket_name,
-                                    Key=json_key
+                                    Bucket=self.s3_loader.bucket_name, Key=json_key
                                 )
-                                content = response['Body'].read().decode('utf-8')
+                                content = response["Body"].read().decode("utf-8")
                                 import json as json_module
+
                                 json_data = json_module.loads(content)
 
                                 if isinstance(json_data, list):
@@ -629,8 +695,8 @@ class DataProcessor:
                     # JSON 데이터 인덱싱
                     json_dict = {}
                     for item in json_data_list:
-                        if isinstance(item, dict) and 'rec_idx' in item:
-                            json_dict[item['rec_idx']] = item
+                        if isinstance(item, dict) and "rec_idx" in item:
+                            json_dict[item["rec_idx"]] = item
 
                     logger.info(f"📋 {len(json_dict)}개의 JSON 레코드 인덱싱 완료")
 
@@ -647,28 +713,40 @@ class DataProcessor:
 
                             if clean_text_result.strip():
                                 pdf_filename = pdf_path.stem
-                                rec_idx = pdf_filename.split('_')[-1] if '_' in pdf_filename else pdf_filename
+                                rec_idx = (
+                                    pdf_filename.split("_")[-1]
+                                    if "_" in pdf_filename
+                                    else pdf_filename
+                                )
 
                                 json_metadata = json_dict.get(rec_idx)
 
                                 metadata = {
                                     "source": "pdf",
                                     "filename": pdf_path.name,
-                                    "document_type": "recruitment_pdf_with_json" if json_metadata else "recruitment_pdf_only",
-                                    "rec_idx": rec_idx
+                                    "document_type": (
+                                        "recruitment_pdf_with_json"
+                                        if json_metadata
+                                        else "recruitment_pdf_only"
+                                    ),
+                                    "rec_idx": rec_idx,
                                 }
 
                                 if json_metadata:
                                     for key, value in json_metadata.items():
                                         if isinstance(value, (str, int, float, bool)):
                                             metadata[key] = str(value)
-                                    logger.info(f"✅ 매칭: {rec_idx} - {json_metadata.get('post_title', 'Unknown')[:30]}...")
+                                    logger.info(
+                                        f"✅ 매칭: {rec_idx} - {json_metadata.get('post_title', 'Unknown')[:30]}..."
+                                    )
                                 else:
-                                    metadata.update({
-                                        "post_title": "제목 없음",
-                                        "deadline": "미정",
-                                        "detail_url": ""
-                                    })
+                                    metadata.update(
+                                        {
+                                            "post_title": "제목 없음",
+                                            "deadline": "미정",
+                                            "detail_url": "",
+                                        }
+                                    )
 
                                 pdf_documents.append(clean_text_result)
                                 pdf_metadatas.append(metadata)
@@ -680,7 +758,9 @@ class DataProcessor:
 
                     # 임베딩 생성 및 Upsert (배치 내에서는 한번에 처리)
                     if pdf_documents:
-                        logger.info(f"🔮 임베딩 생성 중... ({len(pdf_documents)}개 문서)")
+                        logger.info(
+                            f"🔮 임베딩 생성 중... ({len(pdf_documents)}개 문서)"
+                        )
 
                         try:
                             # 임베딩 생성
@@ -694,7 +774,7 @@ class DataProcessor:
                                 ids=pdf_ids,
                                 metadatas=pdf_metadatas,
                                 persist_dir=self.persist_dir,
-                                force_update=force_update
+                                force_update=force_update,
                             )
 
                             # 통계 누적
@@ -703,10 +783,12 @@ class DataProcessor:
                             total_skipped += upsert_result["skipped"]
                             total_processed += len(pdf_documents)
 
-                            logger.info(f"✅ 배치 {batch_num}/{total_batches} 완료: "
-                                      f"추가 {upsert_result['added']}, "
-                                      f"업데이트 {upsert_result['updated']}, "
-                                      f"스킵 {upsert_result['skipped']}")
+                            logger.info(
+                                f"✅ 배치 {batch_num}/{total_batches} 완료: "
+                                f"추가 {upsert_result['added']}, "
+                                f"업데이트 {upsert_result['updated']}, "
+                                f"스킵 {upsert_result['skipped']}"
+                            )
 
                         except Exception as e:
                             logger.error(f"❌ 배치 {batch_num} 임베딩/Upsert 실패: {e}")
@@ -724,17 +806,17 @@ class DataProcessor:
                         self.s3_loader.cleanup_temp_files(pdf_paths)
 
                     # 변수 명시적 삭제 (존재하는 경우만 삭제)
-                    if 'pdf_paths' in locals():
+                    if "pdf_paths" in locals():
                         del pdf_paths
-                    if 'downloaded_pdf_paths' in locals():
+                    if "downloaded_pdf_paths" in locals():
                         del downloaded_pdf_paths
-                    if 'json_data_list' in locals():
+                    if "json_data_list" in locals():
                         del json_data_list
-                    if 'json_dict' in locals():
+                    if "json_dict" in locals():
                         del json_dict
-                    if 'pdf_documents' in locals():
+                    if "pdf_documents" in locals():
                         del pdf_documents, pdf_metadatas, pdf_ids
-                    if 'batch_embeddings' in locals():
+                    if "batch_embeddings" in locals():
                         del batch_embeddings
 
                     # 가비지 컬렉션 강제 실행
@@ -750,7 +832,7 @@ class DataProcessor:
                 "added": total_added,
                 "updated": total_updated,
                 "skipped": total_skipped,
-                "total_processed": total_processed
+                "total_processed": total_processed,
             }
 
             logger.info(f"\n{'='*60}")
@@ -762,11 +844,12 @@ class DataProcessor:
         except Exception as e:
             logger.error(f"❌ rec_idx 리스트 처리 중 오류 발생: {e}")
             import traceback
+
             traceback.print_exc()
             return {
                 "success": False,
                 "error": str(e),
                 "added": 0,
                 "updated": 0,
-                "skipped": 0
+                "skipped": 0,
             }

--- a/llm-service/src/api/routes.py
+++ b/llm-service/src/api/routes.py
@@ -5,6 +5,7 @@ from src.services.llm_prompting import LLMPromptingService, IntentType
 from src.config.config import settings
 from src.services.ingestion_client import IngestionClient
 import logging
+import httpx
 
 router = APIRouter()
 
@@ -83,8 +84,30 @@ async def generate_llm_response(request: LLMRequest):
         # 2) 의도에 따라 문서 검색 여부 결정
         # --------------------------------------------------
         if intent == IntentType.SEARCH_NEEDED:
-            ingestion_client = IngestionClient()
-            relevant_docs = await ingestion_client.retrieve_documents(profile_with_query)
+            ingestion_url = settings.INGESTION_SERVICE_URL
+            try:
+                ingestion_client = IngestionClient()
+                logger.info(f"🔍 Ingestion 서비스 연결 시도: {ingestion_url}")
+                relevant_docs = await ingestion_client.retrieve_documents(profile_with_query)
+                logger.info(f"✅ 문서 검색 완료: {len(relevant_docs)}개 문서 발견")
+            except httpx.ConnectTimeout as e:
+                logger.error(f"⏱️ Ingestion 서비스 연결 타임아웃: {ingestion_url}")
+                raise HTTPException(
+                    status_code=503,
+                    detail=f"Ingestion 서비스에 연결할 수 없습니다. (타임아웃) URL: {ingestion_url}"
+                )
+            except httpx.ConnectError as e:
+                logger.error(f"🔌 Ingestion 서비스 연결 실패: {ingestion_url}")
+                raise HTTPException(
+                    status_code=503,
+                    detail=f"Ingestion 서비스에 연결할 수 없습니다. URL: {ingestion_url}"
+                )
+            except httpx.HTTPStatusError as e:
+                logger.error(f"❌ Ingestion 서비스 HTTP 에러: {e.response.status_code} - {e.response.text}")
+                raise HTTPException(
+                    status_code=503,
+                    detail=f"Ingestion 서비스 오류: {e.response.status_code} - {str(e)}"
+                )
         else:
             relevant_docs = []
 
@@ -102,7 +125,14 @@ async def generate_llm_response(request: LLMRequest):
         logger.info("✅ LLM 응답 생성 완료 | recommended_jobs=%s", len(response.recommended_jobs))
         return response
     
+    except HTTPException:
+        # HTTPException은 그대로 재발생
+        raise
     except Exception as e:
-        logger.error("💥 LLM 응답 생성 실패: %s", str(e), exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        error_msg = str(e) if str(e) else f"{type(e).__name__}: {repr(e)}"
+        logger.error("💥 LLM 응답 생성 실패: %s", error_msg, exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail=f"LLM 응답 생성 중 오류가 발생했습니다: {error_msg}"
+        )
 

--- a/llm-service/src/services/ingestion_client.py
+++ b/llm-service/src/services/ingestion_client.py
@@ -1,5 +1,7 @@
 import httpx
 from typing import List, Optional
+
+# Docker 프로덕션 환경과 동일하게 from src... 형태 사용
 from src.api.models import RetrievalRequest, JobPosting
 from src.config.config import settings
 import logging
@@ -12,23 +14,29 @@ class IngestionClient:
         self.base_url = settings.INGESTION_SERVICE_URL
         self.timeout = settings.INGESTION_REQUEST_TIMEOUT
 
-    async def retrieve_documents(
-        self, profile: RetrievalRequest
-    ) -> List[JobPosting]:
+    async def retrieve_documents(self, profile: RetrievalRequest) -> List[JobPosting]:
         """Ingestion 서비스에서 관련 문서를 검색합니다."""
-        
+
         async with httpx.AsyncClient() as client:
             # Ingestion API 호출
+            # Pydantic v2 호환성: model_dump() 우선 사용
+            if hasattr(profile, 'model_dump'):
+                profile_dict = profile.model_dump()
+            elif hasattr(profile, 'dict'):
+                profile_dict = profile.dict()
+            else:
+                profile_dict = dict(profile) if hasattr(profile, '__iter__') else {}
+            
             response = await client.post(
                 f"{self.base_url}/retrieval",
-                json=profile.dict(),
+                json=profile_dict,
                 timeout=self.timeout,
             )
             response.raise_for_status()
 
             # 응답 파싱
             response_data = response.json()
-            documents_data = response_data.get("results", []) 
+            documents_data = response_data.get("results", [])
             # Dict를 JobPosting 객체로 변환
             documents = []
             for doc_data in documents_data:
@@ -39,7 +47,7 @@ class IngestionClient:
                     deadline=doc_data.get("deadline"),
                     start_date=doc_data.get("start_date"),
                     crawling_time=doc_data.get("crawling_time"),
-                    content=doc_data.get("content", "")
+                    content=doc_data.get("content", ""),
                 )
                 documents.append(job_posting)
 
@@ -64,6 +72,8 @@ class IngestionClient:
 
     async def get_posting(self, rec_idx: str):
         async with httpx.AsyncClient() as client:
-            resp = await client.get(f"{self.base_url}/post/{rec_idx}", timeout=self.timeout)
+            resp = await client.get(
+                f"{self.base_url}/post/{rec_idx}", timeout=self.timeout
+            )
             resp.raise_for_status()
             return resp.json()

--- a/llm-service/src/services/llm_prompting.py
+++ b/llm-service/src/services/llm_prompting.py
@@ -441,11 +441,25 @@ class LLMPromptingService:
 
             # LangChain with_structured_output 방식
             structured_llm = self.llm.with_structured_output(JobRecommendationResponse)
-            result: JobRecommendationResponse = await structured_llm.ainvoke(prompt)
-            function_args = result.dict()
+            result = await structured_llm.ainvoke(prompt)
+            
+            # result가 dict인지 Pydantic 모델인지 확인하여 처리
+            if isinstance(result, dict):
+                function_args = result
+            elif hasattr(result, 'model_dump'):
+                # Pydantic v2
+                function_args = result.model_dump()
+            elif hasattr(result, 'dict'):
+                # Pydantic v1
+                function_args = result.dict()
+            else:
+                # 기본적으로 dict로 변환 시도
+                function_args = dict(result) if hasattr(result, '__iter__') else {}
 
             # LLM structured output 결과 로깅
             logger.info(f"🤖 LLM Structured Output 결과:")
+            logger.info(f"  - function_args 타입: {type(function_args)}")
+            logger.info(f"  - function_args 키: {list(function_args.keys()) if isinstance(function_args, dict) else 'N/A'}")
             logger.info(
                 f"  - recommended_job_indices: {function_args.get('recommended_job_indices', [])}"
             )
@@ -459,21 +473,32 @@ class LLMPromptingService:
                 f"  - practical_tips 길이: {len(function_args.get('practical_tips', ''))}"
             )
 
+            # 필수 필드 확인 및 기본값 설정
+            recommended_job_indices = function_args.get('recommended_job_indices', [])
+            overall_advice = function_args.get('overall_advice', '')
+            practical_tips = function_args.get('practical_tips', '')
+            recommendation_reasons = function_args.get('recommendation_reasons', [])
+
+            # 필수 필드가 없는 경우 경고
+            if not isinstance(function_args, dict) or not function_args:
+                logger.error(f"⚠️ LLM 응답이 예상 형식이 아닙니다. function_args: {function_args}")
+                raise ValueError(f"LLM 응답 형식 오류: 예상한 구조가 아닙니다. 받은 데이터: {type(function_args)}")
+
             # 전체 응답 텍스트 생성
-            if function_args["recommended_job_indices"]:
+            if recommended_job_indices:
                 # 채용공고 추천이 있는 경우 - 제목 목록 제거, 조언과 팁만 포함
                 llm_response = f"""
-{function_args['overall_advice']}
+{overall_advice}
 
 실무 팁:
-{function_args['practical_tips']}
+{practical_tips}
 """.strip()
             else:
                 # 일반 상담/조언인 경우 (채용공고 추천 없음)
                 llm_response = f"""
-{function_args['overall_advice']}
+{overall_advice}
 
-{function_args['practical_tips']}
+{practical_tips}
 """.strip()
 
             # 추천된 채용공고 파싱


### PR DESCRIPTION
# What is this PR? 🔍

## ➕ 이슈 링크
- issue : #158 

## ➕ 개요

Experiment에서 검증한 섹션별 청킹 전략을 실제 서비스에 적용하여 RAG 성능을 개선하는 목적에 있습니다. 

**주요 변경사항 **
- Ingestion 서비스: 문서 단위 → 섹션별 청킹 전략 적용
- Docker compose: 서비스 간 통신 설정 변경( 로컬에서 실험) 
- LLM Service: 에러 핸들링 
- Crawler: 스케쥴려 의존성 추가 
- 

## ➕ 작업 내용

<!---- 변경 사항에 대해 자세하게 작성해주세요. -->
#### 1-1. JobPostParser 구현
- 채용공고 구조화된 파싱 기능 추가
- 섹션 감지 및 추출 (preferred, qualifications, job_duties 등)
- 회사명 및 직무명 자동 추출
- 텍스트 정규화 및 섹션 그룹화

**변경 파일:**
- `ingestion/src/preprocessing/job_post_parser.py` 

#### 1-2. StructuredDocumentLoader 구현
- 섹션별 청킹 로더 구현
- 각 섹션을 독립적인 청크로 처리
- 섹션별 메타데이터 보존
- Fallback 청크 생성 메커니즘

**변경 파일:**
- `ingestion/src/preprocessing/structured_loader.py` (신규)
- `ingestion/src/preprocessing/__init__.py`

#### 1-3. DataProcessor에 StructuredDocumentLoader 통합
process_s3_data, process_incremental_data 등 주요 처리 메서드에 StructuredDocumentLoader 적용

기존 레거시 로직과 하위 호환성 유지

**변경 파일:**
- `ingestion/src/services/data_processor.py`

#### 1-4. 청크 단위 임베딩 및 저장 로직 수정
- 문서 단위 → 청크 단위 임베딩으로 변경
- 청크별 고유 ID 생성 및 관리
- 메타데이터 강화 (섹션 타입, 회사명, 직무명 등)

**변경 파일:**
- `ingestion/src/services/data_processor.py`
- `ingestion/src/api/routes.py`

#### 1-5. 메타데이터 보존 강화
- 청크 ID, 섹션 타입, 회사명, 직무명 등 상세 메타데이터 저장
- 검색 시 더 많은 컨텍스트 정보 활용 가능

**변경 파일:**
- `ingestion/src/preprocessing/structured_loader.py`
- `ingestion/src/services/data_processor.py`

#### 1-6. 증분 업데이트 로직 수정
- 증분 업데이트 시에도 섹션별 청킹 적용
- 중복 방지 및 업데이트 로직 개선

**변경 파일:**
- `ingestion/src/services/data_processor.py`

#### 1-7. 검색 결과 처리 로직 수정
- 문서 단위 → 청크 단위 검색 결과 반환
- 더 세밀한 검색 결과 제공

**변경 파일:**
- `ingestion/src/api/routes.py`
- `ingestion/src/api/models.py`

### Phase 2: Docker 환경 설정 변경 
- `llm-service`에 `INGESTION_SERVICE_URL` 환경 변수 추가
- Docker 네트워크 내부 서비스 이름 사용 (`http://ingestion:5002`)
- `depends_on`으로 서비스 시작 순서 보장
- 외부 IP 의존성 제거

**변경 파일:**
- `docker-compose.yml`

**수정 전:**
```yaml
llm-service:
  # INGESTION_SERVICE_URL 환경 변수 없음
  # 외부 IP 사용 (http://54.180.152.44:5002)
```

**수정 후:**
```yaml
llm-service:
  environment:
    - INGESTION_SERVICE_URL=http://ingestion:5002
  depends_on:
    - ingestion
```

#### 2-2. Crawler 스케줄러 의존성 추가
- APScheduler 의존성 추가 (`apscheduler==3.10.4`)
- 타임존 처리 라이브러리 추가 (`pytz==2024.1`)
- 스케줄러 정상 작동 보장

**변경 파일:**
- `crawler/requirements.txt`

**문제:**
- `scheduler.py` 실행 시 `ModuleNotFoundError: No module named 'apscheduler'` 발생

**해결:**
- `apscheduler` 및 `pytz` 의존성 추가

#### 2-3. LLM Service 에러 핸들링 개선
- Ingestion 서비스 연결 실패 시 상세한 에러 메시지 제공
- 타임아웃, 연결 실패, HTTP 에러 구분 처리
- 503 상태 코드로 서비스 불가 명시
- 로깅 강화

**변경 파일:**
- `llm-service/src/api/routes.py`

**수정 전:**
- 연결 실패 시 빈 에러 메시지 반환
- 모든 에러를 동일하게 처리

**수정 후:**
- 타임아웃: "Ingestion 서비스에 연결할 수 없습니다. (타임아웃) URL: ..."
- 연결 실패: "Ingestion 서비스에 연결할 수 없습니다. URL: ..."
- HTTP 에러: "Ingestion 서비스 오류: {status_code} - {message}"

#### 2-4. Pydantic v2 호환성 개선
- `.dict()` → `.model_dump()` 메서드 사용
- dict와 Pydantic 모델 모두 처리 가능하도록 개선
- 안전한 데이터 접근 (`.get()` 메서드 사용)

**변경 파일:**
- `llm-service/src/services/ingestion_client.py`
- `llm-service/src/services/llm_prompting.py`


## 해결되지 않은 문제 
### 1. GT 생성 파이프라인 관련 파일 
GT 생성 파이프라인 미포함: GT(Ground Truth) 생성 API 관련 코드는 정리가 필요하여 이번 PR에서 제외되었습니다.

###LLM Service Test 오류: LLM Service 테스트 중, 3개의 추천 공고를 요청했으나 응답이 정상적으로 오지 않는 현상이 발견되었습니다. (일반 응답만 해주고 추천 채용공고는 출력 x) 